### PR TITLE
fix(replace svg with font awesome icon)

### DIFF
--- a/templates/portal/index.html
+++ b/templates/portal/index.html
@@ -74,7 +74,9 @@
             <div class="d-inline-flex gap-2 mb-5">
                 <a class="d-inline-flex align-items-center btn btn-primary btn-lg px-4 rounded-pill"
                    href="{% url 'account_signup' %}"
-                   role="button">Sign up</a>
+                   role="button">Sign up
+                    <i class="fa-solid fa-arrow-right ms-2"></i>
+                </a>
                 <a class="btn btn-outline-secondary btn-lg px-4 rounded-pill"
                    href="{% url 'account_login' %}"
                    role="button">Login</a>


### PR DESCRIPTION
Fix #79 

Replace SVG with Font Awesome icon as suggested by @Mariatta 

- Updated signup button to use `<i class="fa-solid fa-arrow-right ms-2">` instead of SVG.
