### PR TITLE
136 link to the portal site and discord from the docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Python cache
 __pycache__/
 *.py[cod]
+.cache
 
 # Virtual envs
 .venv/

--- a/docs/developer/contributing.md
+++ b/docs/developer/contributing.md
@@ -10,6 +10,8 @@ description: Contributing to PyLadiesCon Portal
 Open an issue in our [repo](https://github.com/pyladies/pyladiescon-portal),
 or [start a discussion item](https://github.com/pyladies/pyladiescon-portal/discussions) on GitHub.
 
+Ask questions in the **[#portal_dev](https://discord.gg/X6fcufjb)** channel of our Discord comunity.
+
 ## Running Tests
 
 Tests are run using [pytest](https://docs.pytest.org/en/latest/).

--- a/docs/developer/setup.md
+++ b/docs/developer/setup.md
@@ -45,6 +45,9 @@ The documentation is built using [MKDocs](https://www.mkdocs.org/) and markdown.
 
     ```
     python3 -m venv venv
+    ```
+    
+    ```
     source venv/bin/activate
     ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -55,6 +55,9 @@ edit_uri: edit/main/docs/
 extra:
   homepage: https://conference.pyladies.com
   social:
+    - icon: fontawesome/brands/discord
+      link: https://discord.com/invite/2fUN4ddVfP
+      name: Join our Discord
     - icon: fontawesome/brands/mastodon
       link: https://fosstodon.org/@pyladies
       name: Follow us on Mastodon

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://squidfunk.github.io/mkdocs-material/schema.json
-site_name: PyLadiesCon Portal
+site_name: PyLadiesCon Portal Docs
 site_url: https://pyladiescon-portal-docs.netlify.app
 theme:
   name: material

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -48,6 +48,7 @@ nav:
     - Terms of Service: policies/terms_of_use.md
     - Acceptable Use Policy: policies/acceptable_use_policy.md
     - Code of Conduct: https://global-conference-2025.netlify.app/en/coc/
+  - Portal: https://portal.pyladies.com/
 repo_url: https://github.com/pyladies/pyladiescon-portal
 repo_name: pyladies/pyladiescon-portal
 edit_uri: edit/main/docs/


### PR DESCRIPTION
This PR adds links for the discord and portal to the docs website.
It also changes the name of the Docs site to reduce confusion with the actual portal.
It also fixes two small bugs with the documentation and the .gitignore.
See [the issue](https://github.com/pyladies/pyladiescon-portal/issues/136) for the design.

I am happy to rearrange some of the elements or place the links in a different place, just let me know!