### PR TITLE
Fixed languages spoken bug

### DIFF
--- a/templates/volunteer/volunteerprofile_form.html
+++ b/templates/volunteer/volunteerprofile_form.html
@@ -227,9 +227,7 @@
             $('.select2-multiple').select2({
                 theme: 'classic',
                 placeholder: 'Start typing to select languages...',
-                allowClear: true,
                 width: '100%',
-                closeOnSelect: false
             });
         });
     </script>


### PR DESCRIPTION
In this PR, I aim to fix the languages spoken text box. I note that when a user types a value and subsequently chose a language, the typed values remain on the cell. For example, if I were to put `chi` and selected `Chinese` subsequently, `chi` remains on the text box. In addition, when trying to remove the selected languages and backspace is clicked, all the languages in the text box are removed. 

This could be fixed by removing 2 parameters (`allowClear: true` and `closeOnSelect: false`).

After this fix, the typed values (i.e. `chi`) would be removed, and user can type on a blank start. In addition, when backspace is clicked, the last language converts into text and user is allowed to tweak accordingly.