### PR TITLE
Fix admin list_display error for PortalProfile and VolunteerProfile

### DIFF
--- a/portal_account/admin.py
+++ b/portal_account/admin.py
@@ -6,8 +6,8 @@ from .models import PortalProfile
 class PortalProfileAdmin(admin.ModelAdmin):
     list_display = (
         "user",
-        "user__first_name",
-        "user__last_name",
+        "get_first_name",  
+        "get_last_name",
         "pronouns",
         "coc_agreement",
         "tos_agreement",
@@ -16,5 +16,12 @@ class PortalProfileAdmin(admin.ModelAdmin):
     list_filter = ("pronouns", "coc_agreement", "tos_agreement")
     readonly_fields = ("coc_agreement", "tos_agreement")
 
+    @admin.display(ordering="user__first_name", description="First Name")
+    def get_first_name(self, obj):
+        return obj.user.first_name
+
+    @admin.display(ordering="user__last_name", description="Last Name")
+    def get_last_name(self, obj):
+        return obj.user.last_name
 
 admin.site.register(PortalProfile, PortalProfileAdmin)


### PR DESCRIPTION
- Description

This pull request fixes the admin.E108 errors caused by invalid field references in the list_display attributes of PortalProfileAdmin and VolunteerProfileAdmin.

- Changes made

Replaced "user__first_name", "user__last_name", and "user__email" in list_display with properly defined methods:

get_first_name(self, obj)

get_last_name(self, obj)

get_email(self, obj)

Used @admin.display(...) decorators to allow ordering and customize column names.

- Reason

Django's list_display does not support double underscore lookups like user__first_name. These need to be replaced with callable attributes or methods to avoid admin.E108 system check errors.

- Result

The admin panel now displays user first name, last name, and email correctly without triggering system errors.

