### PR TITLE
Fix sending notification email to internal staff members upon new volunteer approval.

### DIFF
--- a/tests/volunteer/test_models.py
+++ b/tests/volunteer/test_models.py
@@ -511,6 +511,16 @@ class TestVolunteerModel:
     ):
         settings.GDRIVE_FOLDER_ID = "super-secret-folder-id"
 
+        admin_user_to_notify = User.objects.create_superuser(
+            username="testadmin",
+            email="test-admin@example.com",
+            password="pyladiesadmin123",
+        )
+        admin_profile = VolunteerProfile(user=admin_user_to_notify)
+        admin_profile.languages_spoken = [LANGUAGES[0]]
+        admin_profile.region = Region.NORTH_AMERICA
+        admin_profile.save()
+
         profile = VolunteerProfile(user=portal_user)
         profile.languages_spoken = [LANGUAGES[0], LANGUAGES[1]]
         profile.region = Region.NORTH_AMERICA
@@ -521,6 +531,7 @@ class TestVolunteerModel:
             short_name="Super random team name", description="Development Team"
         )
         profile.teams.add(team)
+
         role = Role.objects.create(
             short_name="Obscure Role name", description="Test role desc"
         )
@@ -544,6 +555,16 @@ class TestVolunteerModel:
 
     def test_internal_admin_onboarding_email_contains_info(self, portal_user, settings):
         settings.GDRIVE_FOLDER_ID = "super-secret-folder-id"
+
+        admin_user_to_notify = User.objects.create_superuser(
+            username="testadmin",
+            email="test-admin@example.com",
+            password="pyladiesadmin123",
+        )
+        admin_profile = VolunteerProfile(user=admin_user_to_notify)
+        admin_profile.languages_spoken = [LANGUAGES[0]]
+        admin_profile.region = Region.NORTH_AMERICA
+        admin_profile.save()
 
         profile = VolunteerProfile(user=portal_user)
         profile.languages_spoken = [LANGUAGES[0], LANGUAGES[1]]

--- a/volunteer/models.py
+++ b/volunteer/models.py
@@ -299,19 +299,19 @@ def send_volunteer_onboarding_email(instance):
 def send_internal_volunteer_onboarding_email(instance):
     """Notify internal team about a new volunteer onboarding.
     This should only be sent when the volunteer profile is approved.
+
+    Send notification email to staff and admin team members
     """
     if instance.application_status == ApplicationStatus.APPROVED:
         context = {"profile": instance, "GDRIVE_FOLDER_ID": settings.GDRIVE_FOLDER_ID}
         subject = f"{settings.ACCOUNT_EMAIL_SUBJECT_PREFIX} Complete the Volunteer Onboarding for: {instance.user.first_name} {instance.user.last_name}"
-
         for role in instance.roles.all():
             if role.short_name in [RoleTypes.ADMIN, RoleTypes.STAFF]:
                 context["admin_onboarding"] = True
         html_template = "volunteer/email/internal_volunteer_onboarding.html"
         text_template = "volunteer/email/internal_volunteer_onboarding.txt"
-        _send_email(
+        _send_internal_email(
             subject,
-            [instance.user.email],
             html_template=html_template,
             text_template=text_template,
             context=context,


### PR DESCRIPTION
It was sending to the volunteer instead of to the internal team.