### PR TITLE
Fix regex pattern for validating Discord usernames (#209)

### DIFF
--- a/volunteer/models.py
+++ b/volunteer/models.py
@@ -145,7 +145,7 @@ class VolunteerProfile(BaseModel):
     def _validate_discord_username(self):
         if self.discord_username:
             if not re.match(
-                r"^[a-zA-Z0-9](?:[a-zA-Z0-9]|[._-](?=[a-zA-Z0-9])){0,30}[a-zA-Z0-9]$",
+                r"^(?=.{2,32}$)(?!.*\.\.)[a-zA-Z0-9._]+$",
                 self.discord_username,
             ):
                 if len(self.discord_username) < 2 or len(self.discord_username) > 32:
@@ -158,7 +158,7 @@ class VolunteerProfile(BaseModel):
                     raise ValidationError(
                         {
                             "discord_username": "Discord username must consist of alphanumeric characters, "
-                            "dots, underscores, or hyphens, and cannot have consecutive special characters."
+                            "periods, underscores, and cannot have two consecutive periods."
                         }
                     )
 


### PR DESCRIPTION
Fixes Issue #209 

Updates the regex pattern in the `_validate_discord_username()` method to follow the latest Discord username [specifications](https://support.discord.com/hc/en-us/articles/12620128861463-New-Usernames-Display-Names). 

The pattern now validates that usernames are between 2-32 characters only containing letters, numbers, periods, underscores and disallowing two consecutive periods.