### PR TITLE
Uncomments createcachetable in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ default:
 	docker compose run --rm web python manage.py collectstatic --noinput
 
 	# Create createcachetable
-	#docker compose run --rm web python manage.py createcachetable
+	docker compose run --rm web python manage.py createcachetable
 
 	# Mark the state so we don't rebuild this needlessly.
 	mkdir -p .state


### PR DESCRIPTION
As discussed in #250, this PR uncomments the creation of the cache table necessary to run the application locally.