### PR TITLE
Remove obsolete --force-rm flag in Docker 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ default:
 
 .state/docker-build-web: Dockerfile requirements-app.txt requirements-dev.txt
 	# Build our web container for this project.
-	docker compose build --build-arg  USER_ID=$(shell id -u)  --build-arg GROUP_ID=$(shell id -g) --force-rm web
+	docker compose build --build-arg USER_ID=$(shell id -u) --build-arg GROUP_ID=$(shell id -g) web
 
 	# Collect static assets
 	docker compose run --rm web python manage.py collectstatic --noinput --clear


### PR DESCRIPTION
Fixes #251

`--force-rm` is not a valid flag for `docker compose build`. This PR removes the unsupported flag from the Makefile build target.
Tested:
- Verified the build command runs without `--force-rm`:
  `docker compose build --build-arg USER_ID=1000 --build-arg GROUP_ID=1000 web`