### PR TITLE
Ignore root-level JSON files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ site/
 htmlcov/
 /media/
 
+# Root-level JSON (service-account keys, local tooling) — not subdirs
+/*.json
+


### PR DESCRIPTION
Adds `/*.json` to `.gitignore` so local-only artifacts at the repo root can't be accidentally committed — most importantly the service-account key files (`privatekey_pyladiescon_portal_gdrive.json`, `pyladies-admin-388122-cbddd670a1af.json`).

The leading slash anchors the pattern to the repo root, so JSON files in subdirectories are unaffected. No currently-tracked files match the pattern, so nothing is removed from the repo.

Note: this also ignores root-level `package.json` / `package-lock.json` (currently untracked). If those should be committed later, add `!package.json` / `!package-lock.json` exceptions.