### PR TITLE
Plan admin "bring forward returning volunteers" action (#333)

### DIFF
--- a/docs/architecture/multi-year-progress.md
+++ b/docs/architecture/multi-year-progress.md
@@ -148,6 +148,16 @@ Notes:
 ## Phase 9 — Admin actions and polish
 
 - [ ] Admin action: "Clone teams from prior conference" on `Conference`.
+- [ ] Admin action: "Bring forward returning volunteers" (issue #333). On the
+      `VolunteerProfile` changelist (or `Conference`), select prior-year
+      volunteers and create new `VolunteerProfile` rows for the active
+      conference, copying profile fields (social handles, languages, region,
+      chapter, availability) and optionally team/role assignments. New rows
+      land as `PENDING` by default. This is the admin-initiated counterpart to
+      the self-service returning-volunteer pre-fill in Phase 6: #333 wants the
+      organizer to onboard last year's volunteers into this year's teams
+      *without* the volunteer re-filling the form. Depends on the team-clone
+      action above (teams must exist in the new year before assignment).
 - [ ] Admin action: "Freeze stats for this conference" — snapshot live
       aggregations into `historical_snapshot`.
 - [ ] Update `AttendeeProfile.participated_in_previous_event` choices to


### PR DESCRIPTION
Planning/docs-only change. Adds a Phase 9 item to `multi-year-progress.md` capturing the **admin-initiated** path for multi-year volunteers requested in #333.

Issue #333 has two asks:
1. *Choose volunteers from last year and assign them into this year's teams, without them re-filling the form* → **new Phase 9 admin action** (this PR plans it)
2. *Still let new people sign up just for this year* → already covered by the Phase 6 explicit apply flow

The schema support already shipped in Phase 4 (`VolunteerProfile.user` is a FK with `unique_together = ("user", "conference")`, so a volunteer gets one profile per edition — last year's is never overwritten).

This documents the **admin "bring forward" action** as the organizer-driven counterpart to Phase 6's **self-service returning-volunteer pre-fill**:
- Pre-fill (Phase 6): the returning volunteer re-applies; the form is pre-populated; status resets to `PENDING`.
- Bring-forward (Phase 9, this plan): the organizer selects prior-year volunteers and creates new active-conference rows for them — closer to a "copy," but admin-initiated and explicit. Depends on the team-clone action so teams exist in the new year first.

No code or behavior change.

Refs #333