### PR TITLE
Conference in admin import/export + default-active filter (Multi-year #5)

### DIFF
--- a/attendee/admin.py
+++ b/attendee/admin.py
@@ -1,6 +1,7 @@
 from django.contrib import admin
 from import_export import resources
 from import_export.admin import ImportExportModelAdmin
+from import_export.fields import Field
 
 from .models import AttendeeProfile, PretixOrder
 
@@ -25,10 +26,19 @@ class PretixOrderAdmin(admin.ModelAdmin):
 
 
 class AttendeeProfileResource(resources.ModelResource):
+    # Attendees inherit their conference from the order; export the year as a
+    # read-only column (it is never imported back onto the profile). Both
+    # ``order`` and ``order.conference`` are non-null, so the path is safe.
+    conference = Field(column_name="conference", readonly=True)
+
+    def dehydrate_conference(self, obj):
+        return obj.order.conference.year
+
     class Meta:
         model = AttendeeProfile
         fields = (
             "order",
+            "conference",
             "order__name",
             "order__email",
             "order__status",

--- a/docs/architecture/multi-year-progress.md
+++ b/docs/architecture/multi-year-progress.md
@@ -97,13 +97,25 @@ Notes:
 
 ## Phase 5 — Admin and import/export
 
-- [ ] Add `conference` to `VolunteerProfileResource`, default list filter
+- [x] Add `conference` to `VolunteerProfileResource`, default list filter
       to active conference.
-- [~] Add `conference` to `SponsorshipProfileResource`, default list filter
-      to active conference. (List filter + import-time assignment done in
-      Phase 4; explicit `conference` import/export column still TODO.)
-- [ ] Add `conference` to `AttendeeProfileResource`.
-- [ ] Verify existing CSV exports still work and gain a `conference` column.
+- [x] Add `conference` to `SponsorshipProfileResource`, default list filter
+      to active conference.
+- [x] Add `conference` to `AttendeeProfileResource` (export-only, via
+      `order.conference`).
+- [x] Verify existing CSV exports still work and gain a `conference` column.
+
+Notes:
+- `conference` is exported/imported by **year** (via `ForeignKeyWidget`),
+  not the surrogate pk. Rows imported without a conference column fall back
+  to the active edition in `before_save_instance` (this also completes the
+  `VolunteerProfileResource` import fix deferred from Phase 4).
+- "Default list filter to active" is a reusable `ActiveConferenceFilter`
+  (`portal/admin_filters.py`): the changelist lands on the active edition
+  with no query param; `?conference=all` shows every year. Applied to the
+  volunteer and sponsorship profile admins.
+- Admin column/filter visibility on all six models landed in Phase 4.
+- Tests: 381 pass, 100% cov; no schema change (admin-only).
 
 ## Phase 6 — Behavior changes
 

--- a/portal/admin_filters.py
+++ b/portal/admin_filters.py
@@ -1,0 +1,49 @@
+from django.contrib import admin
+
+from .models import Conference
+
+
+class ActiveConferenceFilter(admin.SimpleListFilter):
+    """Conference list filter that defaults to the active edition.
+
+    With no query parameter the changelist shows only the active conference's
+    rows, so the admin lands on the current year by default; ``?conference=all``
+    shows every edition, and each year remains individually selectable.
+
+    Admins whose model reaches the conference indirectly set ``field_path``
+    (e.g. ``"order__conference"``).
+    """
+
+    title = "conference"
+    parameter_name = "conference"
+    field_path = "conference"
+
+    def lookups(self, request, model_admin):
+        return [(str(conf.pk), str(conf)) for conf in Conference.objects.all()]
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if value == "all":
+            return queryset
+        if value:
+            return queryset.filter(**{f"{self.field_path}__pk": value})
+        active = Conference.get_active()
+        if active is not None:
+            return queryset.filter(**{self.field_path: active})
+        return queryset
+
+    def choices(self, changelist):
+        active = Conference.get_active()
+        value = self.value()
+        yield {
+            "selected": value == "all",
+            "query_string": changelist.get_query_string({self.parameter_name: "all"}),
+            "display": "All",
+        }
+        for pk, title in self.lookup_choices:
+            yield {
+                "selected": value == pk
+                or (value is None and active is not None and str(active.pk) == pk),
+                "query_string": changelist.get_query_string({self.parameter_name: pk}),
+                "display": title,
+            }

--- a/sponsorship/admin.py
+++ b/sponsorship/admin.py
@@ -1,7 +1,10 @@
 from django.contrib import admin
 from import_export import resources
 from import_export.admin import ImportExportModelAdmin
+from import_export.fields import Field
+from import_export.widgets import ForeignKeyWidget
 
+from portal.admin_filters import ActiveConferenceFilter
 from portal.models import Conference
 
 from .models import IndividualDonation, SponsorshipProfile, SponsorshipTier
@@ -30,11 +33,17 @@ class SponsorshipTierAdmin(admin.ModelAdmin):
 
 
 class SponsorshipProfileResource(resources.ModelResource):
+    # Export/import the conference by its year rather than the surrogate pk.
+    conference = Field(
+        attribute="conference",
+        column_name="conference",
+        widget=ForeignKeyWidget(Conference, field="year"),
+    )
+
     def before_save_instance(self, instance, row, **kwargs):
         # during 'confirm' step, dry_run is True
         instance.from_import_export = True
-        # Imports predate Phase 5's explicit conference column; tie rows to the
-        # active edition so the now-required conference FK is satisfied.
+        # Rows that omit the conference column belong to the active edition.
         if instance.conference_id is None:
             instance.conference = Conference.get_active()
 
@@ -42,6 +51,7 @@ class SponsorshipProfileResource(resources.ModelResource):
         model = SponsorshipProfile
         fields = (
             "id",
+            "conference",
             "organization_name",
             "sponsor_contact_name",
             "sponsors_contact_email",
@@ -68,7 +78,7 @@ class SponsorshipProfileAdmin(ImportExportModelAdmin):
         "main_contact_user",
     )
     list_filter = (
-        "conference",
+        ActiveConferenceFilter,
         "progress_status",
         "sponsorship_tier",
     )

--- a/tests/attendee/test_admin.py
+++ b/tests/attendee/test_admin.py
@@ -1,0 +1,15 @@
+import pytest
+
+from attendee.admin import AttendeeProfileResource
+from attendee.models import AttendeeProfile, PretixOrder
+
+
+@pytest.mark.django_db
+class TestAttendeeProfileResource:
+    def test_export_includes_conference_year(self, conference):
+        order = PretixOrder.objects.create(order_code="ORDER123", conference=conference)
+        AttendeeProfile.objects.create(order=order)
+        dataset = AttendeeProfileResource().export()
+        assert "conference" in dataset.headers
+        idx = dataset.headers.index("conference")
+        assert str(dataset[0][idx]) == str(conference.year)

--- a/tests/sponsorship/test_admin.py
+++ b/tests/sponsorship/test_admin.py
@@ -1,8 +1,10 @@
 from django.core import mail
 from tablib import Dataset
 
+from portal.models import Conference
 from sponsorship.admin import SponsorshipProfileResource
 from sponsorship.models import (
+    SponsorshipProfile,
     SponsorshipProgressStatus,
 )
 
@@ -52,3 +54,31 @@ class TestSponsorshipImportExport:
         assert len(mail.outbox) == 0  # no email
         resource.import_data(dataset, dry_run=True)
         assert len(mail.outbox) == 0  # no email
+
+    def test_import_assigns_active_conference(self, admin_user, conference):
+        dataset = Dataset()
+        dataset.headers = ["id", "organization_name", "main_contact_user"]
+        dataset.append(["", "Conf Co", str(admin_user.id)])
+        SponsorshipProfileResource().import_data(dataset, dry_run=False)
+        profile = SponsorshipProfile.objects.get(organization_name="Conf Co")
+        assert profile.conference == conference
+
+    def test_import_respects_explicit_conference_year(self, admin_user, conference):
+        past = Conference.objects.create(
+            year=2024, name="PyLadiesCon 2024", slug="2024"
+        )
+        dataset = Dataset()
+        dataset.headers = ["id", "organization_name", "conference", "main_contact_user"]
+        dataset.append(["", "Past Co", "2024", str(admin_user.id)])
+        SponsorshipProfileResource().import_data(dataset, dry_run=False)
+        profile = SponsorshipProfile.objects.get(organization_name="Past Co")
+        assert profile.conference == past
+
+    def test_export_includes_conference_year(self, conference):
+        SponsorshipProfile.objects.create(
+            organization_name="Exp Co", conference=conference
+        )
+        dataset = SponsorshipProfileResource().export()
+        assert "conference" in dataset.headers
+        idx = dataset.headers.index("conference")
+        assert str(conference.year) in [str(row[idx]) for row in dataset]

--- a/tests/volunteer/test_admin.py
+++ b/tests/volunteer/test_admin.py
@@ -1,11 +1,13 @@
 import pytest
 from django.conf import settings
 from django.contrib.admin.sites import AdminSite
+from django.contrib.auth.models import User
 from django.core import mail
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 from tablib import Dataset
 
+from portal.models import Conference
 from volunteer.admin import PyladiesChapterAdmin, VolunteerProfileResource
 from volunteer.constants import ApplicationStatus
 from volunteer.models import PyladiesChapter, VolunteerProfile
@@ -140,3 +142,66 @@ class TestVolunteerImportExport:
         assert len(mail.outbox) == 0  # no email
         resource.import_data(dataset, dry_run=True)
         assert len(mail.outbox) == 0  # no email
+
+    def test_export_includes_conference_year(self, conference):
+        user = User.objects.create_user("exp_vol", email="exp@example.com")
+        VolunteerProfile.objects.create(
+            user=user, conference=conference, discord_username="d"
+        )
+        dataset = VolunteerProfileResource().export()
+        assert "conference" in dataset.headers
+        idx = dataset.headers.index("conference")
+        assert str(dataset[0][idx]) == str(conference.year)
+
+
+@pytest.mark.django_db
+class TestActiveConferenceFilter:
+    """The conference list filter defaults the changelist to the active edition."""
+
+    def _changelist_queryset(self, client, admin_user, query=""):
+        client.force_login(admin_user)
+        url = reverse("admin:volunteer_volunteerprofile_changelist")
+        response = client.get(url + query)
+        assert response.status_code == 200
+        return list(response.context["cl"].queryset)
+
+    def _two_editions(self, conference):
+        """One profile in the active edition, one in a past edition."""
+        active_user = User.objects.create_user("active_vol", email="a@example.com")
+        past = Conference.objects.create(
+            year=2024, name="PyLadiesCon 2024", slug="2024"
+        )
+        past_user = User.objects.create_user("past_vol", email="p@example.com")
+        active_profile = VolunteerProfile.objects.create(
+            user=active_user, conference=conference, discord_username="a"
+        )
+        past_profile = VolunteerProfile.objects.create(
+            user=past_user, conference=past, discord_username="p"
+        )
+        return active_profile, past_profile, past
+
+    def test_defaults_to_active_conference(self, client, admin_user, conference):
+        active_profile, past_profile, _ = self._two_editions(conference)
+        qs = self._changelist_queryset(client, admin_user)
+        assert active_profile in qs
+        assert past_profile not in qs
+
+    def test_all_shows_every_conference(self, client, admin_user, conference):
+        active_profile, past_profile, _ = self._two_editions(conference)
+        qs = self._changelist_queryset(client, admin_user, "?conference=all")
+        assert active_profile in qs
+        assert past_profile in qs
+
+    def test_filter_by_specific_conference(self, client, admin_user, conference):
+        active_profile, past_profile, past = self._two_editions(conference)
+        qs = self._changelist_queryset(client, admin_user, f"?conference={past.pk}")
+        assert past_profile in qs
+        assert active_profile not in qs
+
+    def test_no_active_conference_shows_all(self, client, admin_user, conference):
+        active_profile, past_profile, _ = self._two_editions(conference)
+        conference.is_active = False
+        conference.save()
+        qs = self._changelist_queryset(client, admin_user)
+        assert active_profile in qs
+        assert past_profile in qs

--- a/volunteer/admin.py
+++ b/volunteer/admin.py
@@ -1,6 +1,11 @@
 from django.contrib import admin
 from import_export import resources
 from import_export.admin import ImportExportModelAdmin
+from import_export.fields import Field
+from import_export.widgets import ForeignKeyWidget
+
+from portal.admin_filters import ActiveConferenceFilter
+from portal.models import Conference
 
 from .constants import ApplicationStatus
 from .models import Language, PyladiesChapter, Role, Team, VolunteerProfile
@@ -18,14 +23,26 @@ def bulk_waitlist_volunteers(modeladmin, request, queryset):
 
 
 class VolunteerProfileResource(resources.ModelResource):
+    # Export/import the conference by its year (stable, human-readable) rather
+    # than the surrogate pk.
+    conference = Field(
+        attribute="conference",
+        column_name="conference",
+        widget=ForeignKeyWidget(Conference, field="year"),
+    )
+
     def before_save_instance(self, instance, row, **kwargs):
         # during 'confirm' step, dry_run is True
         instance.from_import_export = True
+        # Rows that omit the conference column belong to the active edition.
+        if instance.conference_id is None:
+            instance.conference = Conference.get_active()
 
     class Meta:
         model = VolunteerProfile
         fields = (
             "id",
+            "conference",
             "user__first_name",
             "user__last_name",
             "user__email",
@@ -62,7 +79,7 @@ class VolunteerProfileAdmin(ImportExportModelAdmin):
         "region",
         "application_status",
     )
-    list_filter = ("conference", "region", "application_status")
+    list_filter = (ActiveConferenceFilter, "region", "application_status")
     actions = [bulk_waitlist_volunteers]
     resource_classes = [VolunteerProfileResource]
 


### PR DESCRIPTION
Phase 5 of the multi-year-conferences series. Surfaces the conference in the admin import/export resources and defaults the year-bound changelists to the active edition. **Admin-only — no schema change, no public/front-facing change.**

## Import/export
- `conference` is now an import/export column on `VolunteerProfileResource` and `SponsorshipProfileResource` — represented by **year** (`ForeignKeyWidget`), so CSVs are human-readable and importable
- `AttendeeProfileResource` gains an **export-only** `conference` column (derived from `order.conference`)
- Rows imported **without** a conference column fall back to the active edition in `before_save_instance` — this also completes the `VolunteerProfileResource` import fix that was deferred from Phase 4

## Default-to-active list filter
- New reusable `ActiveConferenceFilter` (`portal/admin_filters.py`): the changelist lands on the **active** conference by default; `?conference=all` shows every year; each year is individually selectable
- Applied to the volunteer and sponsorship profile admins

(The `conference` column + plain filter visibility on all six models landed in Phase 4.)

## Tests
- Filter behaviour: default → active, `all`, specific year, and the no-active-conference fallback
- Export-includes-conference for all three resources; import-by-year and import-defaults-to-active for sponsorship
- **381 pass, 100% coverage**; isort/black/flake8 clean; `makemigrations --check` clean (no migration)

## Not in scope (later phases)
- Front-facing list filtering + admin year switcher → Phase 6
- Per-user "Your Conferences" history → Phase 10

Refs #321