### PR TITLE
Volunteer admin polish: dual-list M2M pickers, hide deprecated field, year in Team label

### DIFF
--- a/tests/volunteer/test_models.py
+++ b/tests/volunteer/test_models.py
@@ -46,7 +46,7 @@ class TestVolunteerModel:
             conference=conference,
         )
         team.save()
-        assert str(team) == "Test Team"
+        assert str(team) == f"Test Team ({conference.year})"
 
     def test_role_str_representation(self):
         """Test string representation of Role."""

--- a/volunteer/admin.py
+++ b/volunteer/admin.py
@@ -82,6 +82,11 @@ class VolunteerProfileAdmin(ImportExportModelAdmin):
     list_filter = (ActiveConferenceFilter, "region", "application_status")
     actions = [bulk_waitlist_volunteers]
     resource_classes = [VolunteerProfileResource]
+    # Dual-list ("available"/"chosen") pickers for the many-to-many fields.
+    filter_horizontal = ("teams", "roles", "language")
+    # ``languages_spoken`` is deprecated in favour of the ``language`` m2m; hide
+    # it from the admin form (the public form already excludes it).
+    exclude = ("languages_spoken",)
 
 
 class PyladiesChapterResource(resources.ModelResource):

--- a/volunteer/models.py
+++ b/volunteer/models.py
@@ -63,7 +63,9 @@ class Team(BaseModel):
     open_to_new_members = models.BooleanField(default=True)
 
     def __str__(self):
-        return self.short_name
+        # Include the conference year so teams are distinguishable across
+        # editions (e.g. in admin M2M pickers that list every year's teams).
+        return f"{self.short_name} ({self.conference.year})"
 
     @cached_property
     def approved_members(self):


### PR DESCRIPTION
Small Django-admin cleanups for the volunteer profile, found while testing multi-year. Independent of the behavior work.

- **Dual-list pickers**: `filter_horizontal = ("teams", "roles", "language")` on `VolunteerProfileAdmin` — the "available"/"chosen" two-box widget instead of a plain multi-select.
- **Hide deprecated field**: `exclude = ("languages_spoken",)`. `languages_spoken` (a `ChoiceArrayField`) is deprecated in favour of the `language` m2m; it was showing as a *second* language widget in admin. The public apply form already excludes it — this makes admin consistent. (Field/data untouched; just hidden from the form. Full removal of the deprecated field is a separate task.)
- **Year in `Team` label**: `Team.__str__` now returns e.g. `"Program (2025)"`. Because teams are conference-scoped, the admin m2m picker previously listed every year's teams with no way to tell them apart. The year now shows wherever a team is rendered as a string.

No schema change (`makemigrations --check` clean). 381 pass, 100% coverage; black/isort/flake8 clean.