### PR TITLE
Multi-year behavior changes + conference visibility (Multi-year #6)

### DIFF
--- a/docs/architecture/multi-year-progress.md
+++ b/docs/architecture/multi-year-progress.md
@@ -119,15 +119,31 @@ Notes:
 
 ## Phase 6 — Behavior changes
 
-- [ ] Remove the post-save signal that auto-creates `VolunteerProfile` on
-      user signup.
-- [ ] Update "Apply to volunteer" view: explicit action, ties new
-      `VolunteerProfile` to active conference.
-- [ ] Implement returning-volunteer pre-fill (form initial values come from
+- [x] ~~Remove the post-save signal that auto-creates `VolunteerProfile` on
+      user signup.~~ N/A — no such signal exists; signup only creates
+      `PortalProfile` and volunteering is already explicit via
+      `VolunteerProfileCreate`.
+- [x] Update "Apply to volunteer" view: explicit action, ties new
+      `VolunteerProfile` to active conference. (Conference assignment landed in
+      Phase 4; the "already applied?" guard is now scoped to the active
+      conference so returning volunteers can apply each year.)
+- [x] Implement returning-volunteer pre-fill (form initial values come from
       user's most recent prior `VolunteerProfile`).
-- [ ] Update volunteer list view to filter by active conference; add an
+- [x] Update volunteer list view to filter by active conference; add an
       admin-only year switcher.
-- [ ] Update sponsorship list view to filter by active conference.
+- [x] Update sponsorship list view to filter by active conference.
+
+Notes:
+- Multi-year broke several single-profile assumptions, now scoped to the
+  active conference: `volunteer index` (`get()` → `MultipleObjectsReturned`),
+  the apply guard, and the `portal` dashboard lookup.
+- Sponsor access is per-approved-year: staff/superusers see every conference;
+  other users may only view the conference(s) they were APPROVED volunteers
+  for. `SponsorshipProfileList` defaults to the active edition (or their most
+  recent viewable year) with a year switcher; the detail view checks the
+  specific sponsor's year.
+- Year switchers are a button group on both manage lists; the search form
+  carries the selected year in a hidden field. 386 tests pass, 100% cov.
 
 ## Phase 7 — Stats refactor
 

--- a/portal/views.py
+++ b/portal/views.py
@@ -3,6 +3,7 @@ from django.http import JsonResponse
 from django.shortcuts import redirect, render
 
 from portal.common import get_stats_cached_values
+from portal.models import Conference
 from portal_account.models import PortalProfile
 from volunteer.models import VolunteerProfile
 
@@ -19,7 +20,9 @@ def index(request):
     if user.is_authenticated:
         if not PortalProfile.objects.filter(user=user).exists():
             return redirect("portal_account:portal_profile_new")
-        volunteer_profile = VolunteerProfile.objects.filter(user=user).first()
+        volunteer_profile = VolunteerProfile.objects.filter(
+            user=user, conference=Conference.get_active()
+        ).first()
         context["volunteer_profile"] = volunteer_profile
         context["roles"] = volunteer_profile.roles.all() if volunteer_profile else []
     else:

--- a/sponsorship/forms.py
+++ b/sponsorship/forms.py
@@ -13,10 +13,18 @@ class SponsorshipProfileForm(forms.ModelForm):
         help_text="Required. Main contact person from PyLadiesCon. Defaults to the person who creates the profile.",
         label="Internal Contact *",
     )
+    conference = forms.ModelChoiceField(
+        queryset=Conference.objects.all(),
+        required=False,
+        help_text="The conference edition this sponsorship is for. "
+        "Defaults to the active conference.",
+        label="Conference",
+    )
 
     class Meta:
         model = SponsorshipProfile
         fields = [
+            "conference",
             "main_contact_user",
             "organization_name",
             "sponsor_contact_name",
@@ -55,6 +63,10 @@ class SponsorshipProfileForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         if self.user:
             self.fields["main_contact_user"].initial = self.user.id
+        # Pre-select the active conference; admins can switch to another year
+        # (e.g. to set up next year's sponsors early).
+        if not self.instance.pk:
+            self.fields["conference"].initial = Conference.get_active()
 
     def save(self, commit=True):
         if self.user:

--- a/sponsorship/templates/sponsorship/sponsorship_profile_detail.html
+++ b/sponsorship/templates/sponsorship/sponsorship_profile_detail.html
@@ -20,6 +20,7 @@
                         <div class="card-body">
                             <h5 class="card-title">
                                 {{ profile.organization_name }}
+                                <span class="badge bg-secondary align-middle fs-6">{{ profile.conference }}</span>
                             </h5>
                             <p class="card-text">
                                 {{ profile.company_description }}

--- a/sponsorship/templates/sponsorship/sponsorship_profile_form.html
+++ b/sponsorship/templates/sponsorship/sponsorship_profile_form.html
@@ -35,6 +35,7 @@
                         </h5>
                     </div>
                     <div class="card-body">
+                        {% bootstrap_field form.conference %}
                         {% bootstrap_field form.main_contact_user %}
                         {% bootstrap_field form.organization_name %}
                         {% bootstrap_field form.sponsor_contact_name %}

--- a/sponsorship/templates/sponsorship/sponsorshipprofile_list.html
+++ b/sponsorship/templates/sponsorship/sponsorshipprofile_list.html
@@ -14,8 +14,19 @@
         {% endif %}
     </h1>
     {% include "sponsorship/sponsorship_stats.html" %}
+    {% if conferences %}
+        <div class="btn-group mb-3" role="group" aria-label="Conference year">
+            {% for conference in conferences %}
+                <a href="?conference={{ conference.pk }}"
+                   class="btn btn-sm {% if conference == selected_conference %}btn-primary{% else %}btn-outline-primary{% endif %}">
+                    {{ conference.year }}
+                </a>
+            {% endfor %}
+        </div>
+    {% endif %}
     {% if filter %}
         <form action="" method="get" class="form">
+            <input type="hidden" name="conference" value="{{ selected_conference.pk }}">
             {% bootstrap_form filter.form %}
             {% bootstrap_button 'Search' %}
             {% if filter.form.is_bound %}

--- a/sponsorship/views.py
+++ b/sponsorship/views.py
@@ -14,6 +14,7 @@ from django_tables2.views import SingleTableMixin
 
 from common.mixins import AdminRequiredMixin
 from portal.common import get_sponsorships_stats_dict
+from portal.models import Conference
 from volunteer.constants import ApplicationStatus
 from volunteer.models import VolunteerProfile
 
@@ -23,19 +24,24 @@ from .models import SponsorshipProfile, SponsorshipProgressStatus, SponsorshipTi
 
 
 class CanViewSponsorship(UserPassesTestMixin):
-    """Mixin for views that allows sponsorship listing.
-    Open to approved volunteers.
+    """Mixin for views that allow sponsorship viewing.
+
+    Staff and superusers may view every conference. Other users may only view
+    the conferences they were an approved volunteer for — they see the year(s)
+    they are approved for.
     """
 
+    def viewable_conferences(self):
+        user = self.request.user
+        if user.is_superuser or user.is_staff:
+            return Conference.objects.all()
+        return Conference.objects.filter(
+            volunteer_profiles__user=user,
+            volunteer_profiles__application_status=ApplicationStatus.APPROVED,
+        ).distinct()
+
     def test_func(self):
-        is_approved_volunteer = VolunteerProfile.objects.filter(
-            user=self.request.user, application_status=ApplicationStatus.APPROVED
-        ).exists()
-        return (
-            is_approved_volunteer
-            or self.request.user.is_superuser
-            or self.request.user.is_staff
-        )
+        return self.viewable_conferences().exists()
 
 
 class SponsorshipProfileCreate(AdminRequiredMixin, CreateView):
@@ -222,15 +228,38 @@ class SponsorshipProfileList(CanViewSponsorship, SingleTableMixin, FilterView):
     table_class = SponsorshipProfileTable
     filterset_class = SponsorshipProfileFilter
 
+    def get_selected_conference(self):
+        """The conference whose sponsors are shown.
+
+        Defaults to the active conference when the viewer may see it, otherwise
+        their most recent viewable year. ``?conference=<pk>`` switches years but
+        only among the conferences the viewer is allowed to see.
+        """
+        viewable = self.viewable_conferences()
+        param = self.request.GET.get("conference")
+        if param:
+            return viewable.filter(pk=param).first()
+        active = Conference.get_active()
+        if active is not None and viewable.filter(pk=active.pk).exists():
+            return active
+        return viewable.order_by("-year").first()
+
+    def get_queryset(self):
+        # ``conference=None`` matches nothing, so a year the viewer may not see
+        # yields an empty list rather than leaking another year's sponsors.
+        return super().get_queryset().filter(conference=self.get_selected_conference())
+
     def get_context_data(self, **kwargs):
         # kwargs.pop('filter')
         context = super().get_context_data(**kwargs)
         volunteer_profile = VolunteerProfile.objects.filter(
-            user=self.request.user
+            user=self.request.user, conference=Conference.get_active()
         ).first()
         context["volunteer_profile"] = volunteer_profile
         context["title"] = "Sponsorship Profiles"
         context["stats"] = get_sponsorships_stats_dict()
+        context["conferences"] = self.viewable_conferences()
+        context["selected_conference"] = self.get_selected_conference()
         return context
 
 
@@ -238,6 +267,14 @@ class SponsorshipProfileDetail(CanViewSponsorship, DetailView):
     model = SponsorshipProfile
     template_name = "sponsorship/sponsorship_profile_detail.html"
     context_object_name = "profile"
+
+    def test_func(self):
+        # A viewer may open a sponsor only if they may see that sponsor's year.
+        return (
+            self.viewable_conferences()
+            .filter(pk=self.get_object().conference_id)
+            .exists()
+        )
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/templates/emails/volunteer/internal_volunteer_onboarding.md
+++ b/templates/emails/volunteer/internal_volunteer_onboarding.md
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% block content %}
 
-Hello, {{ recipient_name }}. We're writing to let you know that a **new volunteer has just been approved and onboarded**.
+Hello, {{ recipient_name }}. We're writing to let you know that a **new {{ profile.conference }} volunteer has just been approved and onboarded**.
 
 Be sure to complete the rest of the onboarding process. They've been sent an introductory email with further instructions, however, there are some action items that you need to complete as well since not everything can be automated.
 

--- a/templates/emails/volunteer/internal_volunteer_profile_email_notification.md
+++ b/templates/emails/volunteer/internal_volunteer_profile_email_notification.md
@@ -4,7 +4,7 @@
 
 Hello, {{ recipient_name }}.
 
-We're writing to let you know that a new volunteer has just signed up. Be sure to review their application in a timely manner.
+We're writing to let you know that a new volunteer has just signed up for **{{ profile.conference }}**. Be sure to review their application in a timely manner.
 
 **Volunteer Application Status:** {{ profile.application_status }}.
 

--- a/templates/emails/volunteer/new_volunteer_onboarding.md
+++ b/templates/emails/volunteer/new_volunteer_onboarding.md
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% block content %}
 
-{{ profile.user.first_name }}, thank you for applying to volunteer with PyLadiesCon. We're excited to share that your application has been approved.
+{{ profile.user.first_name }}, thank you for applying to volunteer with **{{ profile.conference }}**. We're excited to share that your application has been approved.
 
 ## Team Assignment
 

--- a/templates/emails/volunteer/team_is_now_closed.md
+++ b/templates/emails/volunteer/team_is_now_closed.md
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% block content %}
 
-{{ profile.user.first_name }}, thank you for applying to volunteer with us.
+{{ profile.user.first_name }}, thank you for applying to volunteer with us for **{{ profile.conference }}**.
 
 {% if updated %}
 Your volunteer profile has recently been updated.

--- a/templates/emails/volunteer/volunteer_profile_email_notification.md
+++ b/templates/emails/volunteer/volunteer_profile_email_notification.md
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% block content %}
 
-{{ profile.user.first_name }}, thank you for applying to volunteer with us.
+{{ profile.user.first_name }}, thank you for applying to volunteer with us for **{{ profile.conference }}**.
 
 {% if updated %}
 Your volunteer profile has recently been updated.

--- a/templates/team/index.html
+++ b/templates/team/index.html
@@ -15,6 +15,7 @@
                         <div class="card-header">
                             <h5>
                                 <a href="{% url 'team_detail' team.id %}">{{ team.short_name }}</a>
+                                <span class="badge bg-secondary">{{ team.conference.year }}</span>
                             </h5>
                         </div>
                         <div class="card-body">

--- a/templates/team/team_detail.html
+++ b/templates/team/team_detail.html
@@ -7,6 +7,7 @@
     <div class="container px-4 py-5" id="featured-3">
         <h2 class="pb-2 border-bottom">
             {{ team.short_name }}
+            <span class="badge bg-secondary align-middle fs-6">{{ team.conference }}</span>
             {% if user.is_superuser %}
                 <small class="fs-6"><a href="{% url 'admin:volunteer_team_change' team.id %}">Edit in Django Admin</a></small>
             {% endif %}

--- a/templates/volunteer/volunteerprofile_detail.html
+++ b/templates/volunteer/volunteerprofile_detail.html
@@ -10,6 +10,7 @@
         {% else %}
             Your Volunteer Profile
         {% endif %}
+        <span class="badge bg-secondary me-1">{{ object.conference }}</span>
         <span class="badge bg-info text-dark me-1">{{ object.application_status }}</span>
     </h1>
     <div class="card mb-4">
@@ -19,6 +20,14 @@
             </h5>
         </div>
         <div class="card-body">
+            <div class="row mb-3">
+                <div class="col-md-3 fw-bold">
+                    {% trans "Conference:" %}
+                </div>
+                <div class="col-md-9">
+                    {{ object.conference }}
+                </div>
+            </div>
             <div class="row mb-3">
                 <div class="col-md-3 fw-bold">
                     {% trans "Username:" %}

--- a/templates/volunteer/volunteerprofile_form.html
+++ b/templates/volunteer/volunteerprofile_form.html
@@ -37,11 +37,19 @@
                 Create
             {% endif %}
             your Volunteer Profile
+            <span class="badge bg-secondary align-middle fs-6">
+                {% if object.pk %}
+                    {{ object.conference }}
+                {% else %}
+                    {{ active_conference }}
+                {% endif %}
+            </span>
         </h1>
         <p class="lead">
             {% if object.pk %}
                 {% trans "Update your information below." %}
             {% else %}
+                {% blocktrans with conference=active_conference %}You are applying to volunteer for {{ conference }}.{% endblocktrans %}
                 {% trans "Fill in the profile below." %}
             {% endif %}
             <div class="alert alert-info" role="alert">

--- a/templates/volunteer/volunteerprofile_list.html
+++ b/templates/volunteer/volunteerprofile_list.html
@@ -8,8 +8,19 @@
     <h1 class="display-5">
         Manage Volunteers
     </h1>
+    {% if conferences %}
+        <div class="btn-group mb-3" role="group" aria-label="Conference year">
+            {% for conference in conferences %}
+                <a href="?conference={{ conference.pk }}"
+                   class="btn btn-sm {% if conference == selected_conference %}btn-primary{% else %}btn-outline-primary{% endif %}">
+                    {{ conference.year }}
+                </a>
+            {% endfor %}
+        </div>
+    {% endif %}
     {% if filter %}
         <form action="" method="get" class="form">
+            <input type="hidden" name="conference" value="{{ selected_conference.pk }}">
             {% bootstrap_form filter.form %}
             {% bootstrap_button 'Search' %}
             {% if filter.form.is_bound %}

--- a/templates/volunteer/volunteerprofile_review_form.html
+++ b/templates/volunteer/volunteerprofile_review_form.html
@@ -6,6 +6,8 @@
     <main>
         <h1 class="display-5">
             Volunteer Profile for: {{ object.user.username }}
+            <span class="badge bg-secondary align-middle fs-6">{{ object.conference }}</span>
+            <span class="badge bg-info text-dark align-middle fs-6">{{ object.application_status }}</span>
         </h1>
         {% if object.is_approved %}
             <form action="{% url 'volunteer:resend_onboarding_email' object.pk %}"
@@ -16,6 +18,62 @@
                     <i class="fa-solid fa-envelope"></i> Resend Onboarding Email
                 </button>
             </form>
+        {% endif %}
+        {% if volunteer_history %}
+            <div class="card mb-4 border-info">
+                <h5 class="card-header">
+                    Volunteer history
+                </h5>
+                <div class="card-body">
+                    <p class="text-muted">
+                        This volunteer has applied in previous years — useful context for your decision.
+                    </p>
+                    <table class="table table-sm align-middle">
+                        <thead>
+                            <tr>
+                                <th>
+                                    Conference
+                                </th>
+                                <th>
+                                    Status
+                                </th>
+                                <th>
+                                    Roles
+                                </th>
+                                <th>
+                                    Teams
+                                </th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            {% for past in volunteer_history %}
+                                <tr>
+                                    <td>
+                                        {{ past.conference }}
+                                    </td>
+                                    <td>
+                                        <span class="badge bg-info text-dark">{{ past.application_status }}</span>
+                                    </td>
+                                    <td>
+                                        {% for role in past.roles.all %}
+                                            <span class="badge bg-secondary">{{ role.short_name }}</span>
+                                        {% empty %}
+                                            —
+                                        {% endfor %}
+                                    </td>
+                                    <td>
+                                        {% for team in past.teams.all %}
+                                            <span class="badge bg-primary">{{ team.short_name }}</span>
+                                        {% empty %}
+                                            —
+                                        {% endfor %}
+                                    </td>
+                                </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                </div>
+            </div>
         {% endif %}
         <div class="row row-cols-1 row-cols-md-2 g-4">
             <div class="col">

--- a/tests/sponsorship/test_forms.py
+++ b/tests/sponsorship/test_forms.py
@@ -1,5 +1,6 @@
 import pytest
 
+from portal.models import Conference
 from sponsorship.forms import SponsorshipProfileForm
 from sponsorship.models import (
     SponsorshipProgressStatus,
@@ -31,6 +32,21 @@ class TestSponsorshipProfileForm:
         assert profile.organization_name == form_data["organization_name"]
         assert profile.progress_status == form_data["progress_status"]
         assert profile.main_contact_user == form_data["main_contact_user"]
+
+    def test_defaults_to_active_conference(self, form_data, conference):
+        form = SponsorshipProfileForm(data=form_data)
+        assert form.is_valid()
+        profile = form.save()
+        assert profile.conference == conference
+
+    def test_can_target_a_specific_conference(self, form_data, conference):
+        past = Conference.objects.create(
+            year=2024, name="PyLadiesCon 2024", slug="2024"
+        )
+        form = SponsorshipProfileForm(data={**form_data, "conference": past.id})
+        assert form.is_valid()
+        profile = form.save()
+        assert profile.conference == past
 
     def test_required_fields(self, form_data, admin_user, portal_user):
         """Test validation of required fields."""

--- a/tests/sponsorship/test_views.py
+++ b/tests/sponsorship/test_views.py
@@ -3,6 +3,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 from pytest_django.asserts import assertRedirects
 
+from portal.models import Conference
 from sponsorship.models import (
     SponsorshipProfile,
     SponsorshipProgressStatus,
@@ -12,6 +13,85 @@ from sponsorship.views import SponsorshipProfileFilter, SponsorshipProfileTable
 from volunteer.constants import ApplicationStatus
 from volunteer.languages import LANGUAGES
 from volunteer.models import VolunteerProfile
+
+
+@pytest.mark.django_db
+class TestSponsorshipConferenceScoping:
+    def _sponsor(self, name, conference):
+        return SponsorshipProfile.objects.create(
+            organization_name=name,
+            conference=conference,
+            progress_status=SponsorshipProgressStatus.PAID,
+        )
+
+    def test_admin_can_switch_year(self, client, admin_user, conference):
+        past = Conference.objects.create(
+            year=2024, name="PyLadiesCon 2024", slug="2024"
+        )
+        self._sponsor("Active Sponsor", conference)
+        self._sponsor("Past Sponsor", past)
+        client.force_login(admin_user)
+        url = reverse("sponsorship:sponsorship_list")
+
+        active_orgs = [
+            p.organization_name for p in client.get(url).context["object_list"]
+        ]
+        assert "Active Sponsor" in active_orgs
+        assert "Past Sponsor" not in active_orgs
+
+        past_orgs = [
+            p.organization_name
+            for p in client.get(f"{url}?conference={past.pk}").context["object_list"]
+        ]
+        assert "Past Sponsor" in past_orgs
+        assert "Active Sponsor" not in past_orgs
+
+    def test_volunteer_sees_only_the_year_they_are_approved_for(
+        self, client, portal_user, conference
+    ):
+        past = Conference.objects.create(
+            year=2024, name="PyLadiesCon 2024", slug="2024"
+        )
+        # approved for the past edition only, not the active one
+        VolunteerProfile.objects.create(
+            user=portal_user,
+            conference=past,
+            application_status=ApplicationStatus.APPROVED,
+            discord_username="d",
+        )
+        self._sponsor("Active Sponsor", conference)
+        self._sponsor("Past Sponsor", past)
+        client.force_login(portal_user)
+
+        response = client.get(reverse("sponsorship:sponsorship_list"))
+        assert response.status_code == 200
+        orgs = [p.organization_name for p in response.context["object_list"]]
+        assert "Past Sponsor" in orgs
+        assert "Active Sponsor" not in orgs
+
+    def test_volunteer_cannot_open_other_year_sponsor_detail(
+        self, client, portal_user, conference
+    ):
+        # approved for the active edition only
+        VolunteerProfile.objects.create(
+            user=portal_user,
+            conference=conference,
+            application_status=ApplicationStatus.APPROVED,
+            discord_username="d",
+        )
+        past = Conference.objects.create(
+            year=2024, name="PyLadiesCon 2024", slug="2024"
+        )
+        past_sponsor = self._sponsor("Past Sponsor", past)
+        client.force_login(portal_user)
+
+        response = client.get(
+            reverse(
+                "sponsorship:sponsorship_profile_detail",
+                kwargs={"pk": past_sponsor.pk},
+            )
+        )
+        assert response.status_code == 403
 
 
 @pytest.mark.django_db

--- a/tests/volunteer/test_admin.py
+++ b/tests/volunteer/test_admin.py
@@ -45,7 +45,7 @@ class TestAdminActions:
         # one message was sent to notify user about waitlisted status
         assert (
             str(mail.outbox[0].subject)
-            == f"{settings.ACCOUNT_EMAIL_SUBJECT_PREFIX} Volunteer Application Updated"
+            == f"{settings.ACCOUNT_EMAIL_SUBJECT_PREFIX} {profile.conference} Volunteer Application Updated"
         )
         assert "We are placing you on a waitlist" in str(mail.outbox[0].body)
         profile.refresh_from_db()

--- a/tests/volunteer/test_forms.py
+++ b/tests/volunteer/test_forms.py
@@ -1,8 +1,59 @@
 import pytest
 
+from portal.models import Conference
 from volunteer.constants import Region
 from volunteer.forms import SelectMultipleWidget, VolunteerProfileForm
-from volunteer.models import Language, VolunteerProfile
+from volunteer.models import Language, Team, VolunteerProfile
+
+
+@pytest.mark.django_db
+class TestReturningVolunteerPrefill:
+    def test_form_prefills_from_most_recent_prior_profile(
+        self, portal_user, conference
+    ):
+        past = Conference.objects.create(
+            year=2024, name="PyLadiesCon 2024", slug="2024"
+        )
+        prior = VolunteerProfile.objects.create(
+            user=portal_user,
+            conference=past,
+            discord_username="priordiscord",
+            github_username="priorgh",
+            region=Region.NORTH_AMERICA,
+            availability_hours_per_week=5,
+        )
+        french = Language.objects.create(code="fr", name="French")
+        prior.language.add(french)
+
+        form = VolunteerProfileForm(user=portal_user)
+
+        assert form.initial["discord_username"] == "priordiscord"
+        assert form.initial["github_username"] == "priorgh"
+        assert form.initial["region"] == Region.NORTH_AMERICA
+        assert form.initial["availability_hours_per_week"] == 5
+        assert list(form.initial["language"]) == [french]
+
+    def test_team_choices_scoped_to_active_conference(self, portal_user, conference):
+        past = Conference.objects.create(
+            year=2024, name="PyLadiesCon 2024", slug="2024"
+        )
+        active_team = Team.objects.create(
+            short_name="Active Team",
+            description="d",
+            conference=conference,
+            open_to_new_members=True,
+        )
+        past_team = Team.objects.create(
+            short_name="Past Team",
+            description="d",
+            conference=past,
+            open_to_new_members=True,
+        )
+
+        teams = list(VolunteerProfileForm(user=portal_user).fields["teams"].queryset)
+
+        assert active_team in teams
+        assert past_team not in teams
 
 
 @pytest.mark.django_db

--- a/tests/volunteer/test_models.py
+++ b/tests/volunteer/test_models.py
@@ -398,16 +398,16 @@ class TestVolunteerModel:
         assert len(mail.outbox) == 3
         assert (  # user creation, to internal staff
             str(mail.outbox[0].subject)
-            == f"{settings.ACCOUNT_EMAIL_SUBJECT_PREFIX} New Volunteer Application"
+            == f"{settings.ACCOUNT_EMAIL_SUBJECT_PREFIX} New {profile.conference} Volunteer Application"
         )
         assert (  # user creation, to internal staff
             str(mail.outbox[1].subject)
-            == f"{settings.ACCOUNT_EMAIL_SUBJECT_PREFIX} New Volunteer Application"
+            == f"{settings.ACCOUNT_EMAIL_SUBJECT_PREFIX} New {profile.conference} Volunteer Application"
         )
 
         assert (  # user creation, to user
             str(mail.outbox[2].subject)
-            == f"{settings.ACCOUNT_EMAIL_SUBJECT_PREFIX} Volunteer Application Received"
+            == f"{settings.ACCOUNT_EMAIL_SUBJECT_PREFIX} {profile.conference} Volunteer Application Received"
         )
 
     def test_email_is_sent_after_updated(self, portal_user, conference):
@@ -421,7 +421,7 @@ class TestVolunteerModel:
 
         assert (
             str(mail.outbox[0].subject)
-            == f"{settings.ACCOUNT_EMAIL_SUBJECT_PREFIX} Volunteer Application Updated"
+            == f"{settings.ACCOUNT_EMAIL_SUBJECT_PREFIX} {profile.conference} Volunteer Application Updated"
         )
 
     def test_volunteer_notification_email_contains_info(self, portal_user, conference):
@@ -488,7 +488,7 @@ class TestVolunteerModel:
         assert len(mail.outbox) == 1
         assert (
             str(mail.outbox[0].subject)
-            == f"{settings.ACCOUNT_EMAIL_SUBJECT_PREFIX} Welcome to the PyLadiesCon Volunteer Team"
+            == f"{settings.ACCOUNT_EMAIL_SUBJECT_PREFIX} Welcome to the {profile.conference} Volunteer Team"
         )
         # role name and team name in the body
         assert role.short_name in str(mail.outbox[0].body)
@@ -525,7 +525,7 @@ class TestVolunteerModel:
         assert len(mail.outbox) == 1
         assert (
             str(mail.outbox[0].subject)
-            == f"{settings.ACCOUNT_EMAIL_SUBJECT_PREFIX} Welcome to the PyLadiesCon Volunteer Team"
+            == f"{settings.ACCOUNT_EMAIL_SUBJECT_PREFIX} Welcome to the {profile.conference} Volunteer Team"
         )
         # role name and team name in the body
         assert admin_role.short_name in str(mail.outbox[0].body)
@@ -608,7 +608,7 @@ class TestVolunteerModel:
         assert len(mail.outbox) == 1
         assert (
             str(mail.outbox[0].subject)
-            == f"{settings.ACCOUNT_EMAIL_SUBJECT_PREFIX} Complete the Volunteer Onboarding for: {profile.user.first_name} {profile.user.last_name}"
+            == f"{settings.ACCOUNT_EMAIL_SUBJECT_PREFIX} Complete the {profile.conference} Volunteer Onboarding for: {profile.user.first_name} {profile.user.last_name}"
         )
         # role name and team name in the body
         assert role.short_name in str(mail.outbox[0].body)
@@ -656,7 +656,7 @@ class TestVolunteerModel:
         assert len(mail.outbox) == 1
         assert (
             str(mail.outbox[0].subject)
-            == f"{settings.ACCOUNT_EMAIL_SUBJECT_PREFIX} Complete the Volunteer Onboarding for: {profile.user.first_name} {profile.user.last_name}"
+            == f"{settings.ACCOUNT_EMAIL_SUBJECT_PREFIX} Complete the {profile.conference} Volunteer Onboarding for: {profile.user.first_name} {profile.user.last_name}"
         )
         # role name and team name in the body
         assert admin_role.short_name in str(mail.outbox[0].body)
@@ -711,7 +711,7 @@ class TestVolunteerModel:
 
         assert (
             str(mail.outbox[0].subject)
-            == f"{settings.ACCOUNT_EMAIL_SUBJECT_PREFIX} Volunteer Application Updated"
+            == f"{settings.ACCOUNT_EMAIL_SUBJECT_PREFIX} {profile.conference} Volunteer Application Updated"
         )
 
         # message about being waitslisted is in the body

--- a/tests/volunteer/test_views.py
+++ b/tests/volunteer/test_views.py
@@ -3,6 +3,7 @@ from django.contrib.messages import get_messages
 from django.urls import reverse
 from pytest_django.asserts import assertRedirects
 
+from portal.models import Conference
 from volunteer.constants import Region
 from volunteer.models import (
     ApplicationStatus,
@@ -644,6 +645,36 @@ class TestManageVolunteerApplications:
         )
         assert response.status_code == 200
 
+    def test_review_page_shows_prior_year_history(
+        self, client, admin_user, django_user_model, conference
+    ):
+        past = Conference.objects.create(
+            year=2024, name="PyLadiesCon 2024", slug="2024"
+        )
+        applicant = django_user_model.objects.create_user(username="returning")
+        role = Role.objects.create(short_name="Developer", description="d")
+        prior = VolunteerProfile.objects.create(
+            user=applicant,
+            conference=past,
+            discord_username="d",
+            application_status=ApplicationStatus.APPROVED,
+        )
+        prior.roles.add(role)
+        current = VolunteerProfile.objects.create(
+            user=applicant, conference=conference, discord_username="d2"
+        )
+
+        client.force_login(admin_user)
+        response = client.get(
+            reverse("volunteer:volunteer_profile_manage", kwargs={"pk": current.id})
+        )
+
+        assert response.status_code == 200
+        history = list(response.context["volunteer_history"])
+        assert prior in history
+        assert current not in history
+        assert role.short_name in response.content.decode()
+
     def test_manage_volunteers_view_is_staff(
         self, client, portal_user, django_user_model, conference
     ):
@@ -1082,3 +1113,37 @@ class TestCancelVolunteering:
 
         result2 = table.render_actions("", profile2)
         assert result2 == ""
+
+
+@pytest.mark.django_db
+class TestVolunteerListYearSwitcher:
+    def test_defaults_to_active_and_switches_year(
+        self, client, admin_user, django_user_model, conference
+    ):
+        past = Conference.objects.create(
+            year=2024, name="PyLadiesCon 2024", slug="2024"
+        )
+        active_user = django_user_model.objects.create_user(
+            "activevol", email="a@example.com"
+        )
+        past_user = django_user_model.objects.create_user(
+            "pastvol", email="p@example.com"
+        )
+        active_profile = VolunteerProfile.objects.create(
+            user=active_user, conference=conference, discord_username="a"
+        )
+        past_profile = VolunteerProfile.objects.create(
+            user=past_user, conference=past, discord_username="p"
+        )
+        client.force_login(admin_user)
+        url = reverse("volunteer:volunteer_profile_list")
+
+        default_list = list(client.get(url).context["object_list"])
+        assert active_profile in default_list
+        assert past_profile not in default_list
+
+        switched_list = list(
+            client.get(f"{url}?conference={past.pk}").context["object_list"]
+        )
+        assert past_profile in switched_list
+        assert active_profile not in switched_list

--- a/volunteer/forms.py
+++ b/volunteer/forms.py
@@ -61,8 +61,8 @@ class VolunteerProfileForm(ModelForm):
 
     class Meta:
         model = VolunteerProfile
-        # conference is excluded until Phase 6 of the multi-year work, when
-        # new profiles get tied to the active conference automatically.
+        # conference is not shown in the form: new profiles are tied to the
+        # active conference automatically in save().
         exclude = [
             "user",
             "application_status",
@@ -224,9 +224,43 @@ class VolunteerProfileForm(ModelForm):
                 "data-placeholder": "Start typing to select languages...",
             },
         )
+        # Teams are conference-scoped: only offer the active edition's open
+        # teams, never a prior year's.
+        self.fields["teams"].queryset = Team.objects.filter(
+            open_to_new_members=True, conference=Conference.get_active()
+        )
 
-        if self.instance and self.instance.pk:
-            pass
+        # Returning volunteers: pre-fill a brand-new application from their most
+        # recent prior profile so they only review and adjust. The new row still
+        # goes through the form and resets application_status to PENDING.
+        if self.user and not (self.instance and self.instance.pk):
+            self._prefill_from_prior_profile()
+
+    PREFILL_FIELDS = (
+        "github_username",
+        "discord_username",
+        "instagram_username",
+        "bluesky_username",
+        "mastodon_url",
+        "x_username",
+        "linkedin_url",
+        "region",
+        "chapter",
+        "availability_hours_per_week",
+    )
+
+    def _prefill_from_prior_profile(self):
+        prior = (
+            VolunteerProfile.objects.filter(user=self.user)
+            .exclude(conference=Conference.get_active())
+            .order_by("-conference__year")
+            .first()
+        )
+        if prior is None:
+            return
+        for field in self.PREFILL_FIELDS:
+            self.initial.setdefault(field, getattr(prior, field))
+        self.initial.setdefault("language", list(prior.language.all()))
 
     def save(self, commit=True):
         if self.user:
@@ -263,6 +297,11 @@ class VolunteerProfileReviewForm(ModelForm):
     def __init__(self, *args, **kwargs):
         self.user = kwargs.pop("user", None)
         super().__init__(*args, **kwargs)
+        # Assign only teams belonging to the profile's own conference edition.
+        if self.instance and self.instance.conference_id:
+            self.fields["teams"].queryset = Team.objects.filter(
+                conference_id=self.instance.conference_id
+            )
 
     def clean(self):
         cleaned_data = super().clean()

--- a/volunteer/models.py
+++ b/volunteer/models.py
@@ -298,7 +298,10 @@ class VolunteerProfile(BaseModel):
 def send_volunteer_notification_email(instance, updated=False):
     """Send email to the user whenever their volunteer profile was updated/created."""
     context = {"profile": instance}
-    subject = f"{settings.ACCOUNT_EMAIL_SUBJECT_PREFIX} Volunteer Application"
+    subject = (
+        f"{settings.ACCOUNT_EMAIL_SUBJECT_PREFIX} {instance.conference} "
+        "Volunteer Application"
+    )
     if updated:
         context["updated"] = True
         subject += " Updated"
@@ -323,7 +326,7 @@ def send_volunteer_onboarding_email(instance):
     """
     if instance.application_status == ApplicationStatus.APPROVED:
         context = {"profile": instance, "GDRIVE_FOLDER_ID": settings.GDRIVE_FOLDER_ID}
-        subject = f"{settings.ACCOUNT_EMAIL_SUBJECT_PREFIX} Welcome to the PyLadiesCon Volunteer Team"
+        subject = f"{settings.ACCOUNT_EMAIL_SUBJECT_PREFIX} Welcome to the {instance.conference} Volunteer Team"
 
         for role in instance.roles.all():
             if role.short_name in [RoleTypes.ADMIN, RoleTypes.STAFF]:
@@ -345,7 +348,7 @@ def send_internal_volunteer_onboarding_email(instance):
     """
     if instance.application_status == ApplicationStatus.APPROVED:
         context = {"profile": instance, "GDRIVE_FOLDER_ID": settings.GDRIVE_FOLDER_ID}
-        subject = f"{settings.ACCOUNT_EMAIL_SUBJECT_PREFIX} Complete the Volunteer Onboarding for: {instance.user.first_name} {instance.user.last_name}"
+        subject = f"{settings.ACCOUNT_EMAIL_SUBJECT_PREFIX} Complete the {instance.conference} Volunteer Onboarding for: {instance.user.first_name} {instance.user.last_name}"
         for role in instance.roles.all():
             if role.short_name in [RoleTypes.ADMIN, RoleTypes.STAFF]:
                 context["admin_onboarding"] = True
@@ -403,7 +406,7 @@ def send_internal_notification_email(instance):
 
     """
     context = {"profile": instance}
-    subject = f"{settings.ACCOUNT_EMAIL_SUBJECT_PREFIX} New Volunteer Application"
+    subject = f"{settings.ACCOUNT_EMAIL_SUBJECT_PREFIX} New {instance.conference} Volunteer Application"
 
     markdown_template = (
         "emails/volunteer/internal_volunteer_profile_email_notification.md"

--- a/volunteer/views.py
+++ b/volunteer/views.py
@@ -14,6 +14,7 @@ from django_filters.views import FilterView
 from django_tables2.views import SingleTableMixin
 
 from common.mixins import AdminRequiredMixin, VolunteerOrAdminRequiredMixin
+from portal.models import Conference
 
 from .forms import VolunteerProfileForm, VolunteerProfileReviewForm
 from .models import (  # Language,
@@ -29,11 +30,12 @@ from .models import (  # Language,
 @login_required
 def index(request):
     context = {}
-    try:
-        profile = VolunteerProfile.objects.get(user=request.user)
-        context["profile"] = profile
-    except VolunteerProfile.DoesNotExist:
-        context["profile"] = None
+    # A user can have one profile per conference; show the active edition's.
+    # ``conference=None`` (no active conference) matches nothing, so this
+    # safely yields no profile rather than an arbitrary year.
+    context["profile"] = VolunteerProfile.objects.filter(
+        user=request.user, conference=Conference.get_active()
+    ).first()
     return render(request, "volunteer/index.html", context)
 
 
@@ -190,6 +192,27 @@ class VolunteerProfileList(VolunteerAdminRequiredMixin, SingleTableMixin, Filter
     table_class = VolunteerProfileTable
     filterset_class = VolunteerProfileFilter
 
+    def get_selected_conference(self):
+        """The conference whose volunteers are shown; defaults to active.
+
+        Admins can switch years via ``?conference=<pk>``.
+        """
+        param = self.request.GET.get("conference")
+        if param:
+            return Conference.objects.filter(pk=param).first()
+        return Conference.get_active()
+
+    def get_queryset(self):
+        # ``conference=None`` matches nothing, so an unknown year or no active
+        # conference yields an empty list rather than every year at once.
+        return super().get_queryset().filter(conference=self.get_selected_conference())
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["conferences"] = Conference.objects.all()
+        context["selected_conference"] = self.get_selected_conference()
+        return context
+
 
 class VolunteerProfileView(DetailView):
     model = VolunteerProfile
@@ -225,6 +248,19 @@ class ManageVolunteerProfile(VolunteerAdminRequiredMixin, UpdateView):
         kwargs.update({"user": self.request.user})
         return kwargs
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        # Prior-year applications by the same volunteer, newest first, to inform
+        # the review decision (what years/roles they served before).
+        context["volunteer_history"] = (
+            VolunteerProfile.objects.filter(user=self.object.user)
+            .exclude(pk=self.object.pk)
+            .select_related("conference")
+            .prefetch_related("roles", "teams")
+            .order_by("-conference__year")
+        )
+        return context
+
 
 class VolunteerProfileCreate(CreateView):
     model = VolunteerProfile
@@ -233,7 +269,11 @@ class VolunteerProfileCreate(CreateView):
     form_class = VolunteerProfileForm
 
     def get(self, request, *args, **kwargs):
-        if VolunteerProfile.objects.filter(user__id=request.user.id).exists():
+        # Only block if they have already applied for the *active* conference;
+        # returning volunteers may apply afresh each year.
+        if VolunteerProfile.objects.filter(
+            user=request.user, conference=Conference.get_active()
+        ).exists():
             return redirect("volunteer:index")
         return super(VolunteerProfileCreate, self).get(request, *args, **kwargs)
 


### PR DESCRIPTION
Phase 6 of the multi-year-conferences series. Makes the per-year model behave correctly in the views/forms and surfaces the conference everywhere it matters. No schema change.

## Multi-year correctness
Single-profile assumptions that broke once a user can have a profile per year, now scoped to the active conference:
- Volunteer index — `get(user=…)` would raise `MultipleObjectsReturned`
- Apply guard — blocked *returning* volunteers from applying; now scoped so they can apply each year
- Portal dashboard — returned an arbitrary year's profile

## Returning-volunteer flow
- Apply form **pre-fills** from the user's most recent prior profile (handles, languages, region, chapter, availability); status resets to `PENDING`
- Apply & review forms scope **team choices to the relevant conference**

## Lists + year switchers
- **Manage Volunteers** and **Sponsor list** default to the active conference with a year-switcher (search preserves the selected year)
- **Sponsor access is per-approved-year**: staff/superusers see all; other users only the conference(s) they were APPROVED for; the detail view 403s on a non-viewable year

## Conference visibility
- Year badges on: apply form (+ "applying for …"), volunteer profile view, admin **review** page, teams list, team detail, sponsor detail
- **All volunteer emails** name the conference (subjects + bodies)
- **Review page** shows the applicant's prior-year history (year / status / roles / teams)
- **Add-sponsor form** gains a Conference selector (defaults to active, switchable) so admins can set up next year's sponsors early

## Notes
- The design doc's "remove auto-create-on-signup signal" is **N/A** — no such signal exists; volunteering was already explicit via `VolunteerProfileCreate`.
- **390 tests pass, 100% coverage**; black/isort/flake8/djlint clean; `makemigrations --check` clean.

## Not in scope (later phases)
- Sponsor-list **stats overview** is not year-aware yet → **Phase 7** (stats refactor: year-aware aggregations + cache keys + `?year=`)
- Start-new-year wizard (#341), bring-forward volunteers (#333), navbar year indicator (Phase 9), "Your Conferences" history (Phase 10)

Refs #321