### PR TITLE
Sponsorship tier multi-year polish (sample data + form scoping)

### DIFF
--- a/portal/management/commands/generate_sample_data.py
+++ b/portal/management/commands/generate_sample_data.py
@@ -577,8 +577,8 @@ class Command(BaseCommand):
         for tier_data in tiers_data:
             tier, created = SponsorshipTier.objects.get_or_create(
                 name=tier_data["name"],
+                conference=self.conference,
                 defaults={
-                    "conference": self.conference,
                     "amount": tier_data["amount"],
                     "description": tier_data["description"],
                 },

--- a/sponsorship/forms.py
+++ b/sponsorship/forms.py
@@ -3,7 +3,7 @@ from django.contrib.auth.models import User
 
 from portal.models import Conference
 
-from .models import SponsorshipProfile
+from .models import SponsorshipProfile, SponsorshipTier
 
 
 class SponsorshipProfileForm(forms.ModelForm):
@@ -63,10 +63,29 @@ class SponsorshipProfileForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
         if self.user:
             self.fields["main_contact_user"].initial = self.user.id
+        active = Conference.get_active()
         # Pre-select the active conference; admins can switch to another year
         # (e.g. to set up next year's sponsors early).
         if not self.instance.pk:
-            self.fields["conference"].initial = Conference.get_active()
+            self.fields["conference"].initial = active
+        # Offer only the active edition's tiers (tiers are conference-scoped);
+        # otherwise the dropdown lists every year's tiers.
+        self.fields["sponsorship_tier"].queryset = SponsorshipTier.objects.filter(
+            conference=active
+        )
+
+    def clean(self):
+        cleaned_data = super().clean()
+        tier = cleaned_data.get("sponsorship_tier")
+        conference = cleaned_data.get("conference") or Conference.get_active()
+        # Guard the (selector vs dropdown) gap: a tier must belong to the same
+        # conference the sponsorship is for.
+        if tier and conference and tier.conference_id != conference.pk:
+            self.add_error(
+                "sponsorship_tier",
+                "This tier belongs to a different conference edition.",
+            )
+        return cleaned_data
 
     def save(self, commit=True):
         if self.user:

--- a/sponsorship/models.py
+++ b/sponsorship/models.py
@@ -32,7 +32,9 @@ class SponsorshipTier(BaseModel):
     description = models.TextField()
 
     def __str__(self):
-        return f"{self.name} (${self.amount:.2f})"
+        # Include the conference year so tiers are distinguishable across
+        # editions (the form/admin pickers list every year's tiers).
+        return f"{self.name} (${self.amount:.2f}) — {self.conference.year}"
 
 
 class SponsorshipProfile(BaseModel):

--- a/tests/sponsorship/test_forms.py
+++ b/tests/sponsorship/test_forms.py
@@ -48,6 +48,40 @@ class TestSponsorshipProfileForm:
         profile = form.save()
         assert profile.conference == past
 
+    def test_tier_choices_scoped_to_active_conference(self, conference):
+        past = Conference.objects.create(
+            year=2024, name="PyLadiesCon 2024", slug="2024"
+        )
+        active_tier = SponsorshipTier.objects.create(
+            name="Active Tier", amount=1000, description="d", conference=conference
+        )
+        past_tier = SponsorshipTier.objects.create(
+            name="Past Tier", amount=1000, description="d", conference=past
+        )
+
+        tiers = list(SponsorshipProfileForm().fields["sponsorship_tier"].queryset)
+
+        assert active_tier in tiers
+        assert past_tier not in tiers
+
+    def test_tier_must_match_chosen_conference(self, form_data, conference):
+        past = Conference.objects.create(
+            year=2024, name="PyLadiesCon 2024", slug="2024"
+        )
+        active_tier = SponsorshipTier.objects.create(
+            name="Active Tier", amount=1000, description="d", conference=conference
+        )
+        # Choosing a past edition but an active-edition tier must be rejected.
+        form = SponsorshipProfileForm(
+            data={
+                **form_data,
+                "conference": past.id,
+                "sponsorship_tier": active_tier.id,
+            }
+        )
+        assert not form.is_valid()
+        assert "sponsorship_tier" in form.errors
+
     def test_required_fields(self, form_data, admin_user, portal_user):
         """Test validation of required fields."""
         form = SponsorshipProfileForm(data={})

--- a/tests/sponsorship/test_models.py
+++ b/tests/sponsorship/test_models.py
@@ -37,7 +37,7 @@ class TestSponsorshipModel:
             conference=conference,
         )
         tier.save()
-        assert str(tier) == f"{tier.name} (${tier.amount:.2f})"
+        assert str(tier) == f"{tier.name} (${tier.amount:.2f}) — {conference.year}"
 
     def test_donation_str_representation(self, conference):
         """Test string representation of IndividualDonation."""


### PR DESCRIPTION
Multi-year sponsorship-tier polish surfaced during testing. No new constraint — duplicate tier names within a year stay allowed by design.

## Sample data
- `generate_sample_data` keys `SponsorshipTier.get_or_create` on **`(name, conference)`** instead of `name` alone. Tier names aren't unique and tiers are conference-scoped, so keying on name would match a prior year's tier and skip creating the new year's when generating data for multiple editions.

## Create-sponsor form
- **`SponsorshipTier.__str__`** now includes the conference year (`"Champion ($25000.00) — 2025"`), so the tier dropdown and admin pickers (which list every year's tiers) are distinguishable across editions. Mirrors the `Team.__str__` treatment.
- The form **offers only the active edition's tiers** (tiers are conference-scoped), instead of every year's.
- A **`clean()` guard** rejects a tier whose conference differs from the sponsorship's chosen conference (covers the no-JS gap between the conference selector and the tier dropdown).

## Notes
- Confirmed `SponsorshipTier.conference` is **non-null** (Phase 4) — tiers can't be orphaned from a year. (The nullable link is `SponsorshipProfile.sponsorship_tier` — a *sponsor* may have no tier.)
- No uniqueness constraint added — "Champion" within a single year remains allowed ("easy to fix, easy to see").
- 392 tests pass, 100% coverage; black/isort/flake8 clean; no schema change (`makemigrations --check` clean — `__str__` is a method).