### PR TITLE
Send volunteer emails asynchronously via Celery (closes #242)

### DIFF
--- a/tests/volunteer/test_tasks.py
+++ b/tests/volunteer/test_tasks.py
@@ -1,0 +1,90 @@
+import pytest
+from django.contrib.auth.models import User
+from django.core import mail
+
+from volunteer.constants import ApplicationStatus, Region
+from volunteer.models import Role, Team, VolunteerProfile
+from volunteer.tasks import (
+    send_internal_volunteer_onboarding_email_task,
+    send_volunteer_cancelled_emails_task,
+    send_volunteer_onboarding_email_task,
+    send_volunteer_profile_emails_task,
+)
+
+
+@pytest.fixture
+def staff_recipient(conference):
+    """A staff user who receives internal team notifications."""
+    return User.objects.create_user(
+        username="staffteam", email="staff@example.com", is_staff=True
+    )
+
+
+@pytest.fixture
+def volunteer_profile(portal_user, conference):
+    return VolunteerProfile.objects.create(
+        user=portal_user,
+        conference=conference,
+        discord_username="d",
+        region=Region.NORTH_AMERICA,
+        application_status=ApplicationStatus.APPROVED,
+    )
+
+
+@pytest.mark.django_db
+class TestVolunteerEmailTasks:
+    def test_profile_emails_created(self, volunteer_profile, staff_recipient):
+        mail.outbox.clear()
+        result = send_volunteer_profile_emails_task(volunteer_profile.id, True)
+        assert "Sent volunteer profile emails" in result
+        # applicant notification + internal (staff) notification
+        assert len(mail.outbox) >= 2
+
+    def test_profile_emails_updated(self, volunteer_profile):
+        mail.outbox.clear()
+        result = send_volunteer_profile_emails_task(volunteer_profile.id, False)
+        assert "Sent volunteer profile emails" in result
+        assert len(mail.outbox) == 1
+
+    def test_profile_emails_not_found(self):
+        assert "not found" in send_volunteer_profile_emails_task(99999, True)
+
+    def test_onboarding_email(self, volunteer_profile):
+        mail.outbox.clear()
+        result = send_volunteer_onboarding_email_task(volunteer_profile.id)
+        assert "Sent volunteer onboarding email" in result
+        assert len(mail.outbox) == 1
+
+    def test_onboarding_email_not_found(self):
+        assert "not found" in send_volunteer_onboarding_email_task(99999)
+
+    def test_internal_onboarding_email(self, volunteer_profile, staff_recipient):
+        mail.outbox.clear()
+        result = send_internal_volunteer_onboarding_email_task(volunteer_profile.id)
+        assert "Sent internal volunteer onboarding email" in result
+        assert len(mail.outbox) >= 1
+
+    def test_internal_onboarding_email_not_found(self):
+        assert "not found" in send_internal_volunteer_onboarding_email_task(99999)
+
+    def test_cancelled_emails(self, volunteer_profile, conference):
+        team = Team.objects.create(
+            short_name="Dev", description="d", conference=conference
+        )
+        lead_user = User.objects.create_user(username="lead", email="lead@example.com")
+        lead_profile = VolunteerProfile.objects.create(
+            user=lead_user, conference=conference, discord_username="l"
+        )
+        team.team_leads.add(lead_profile)
+        role = Role.objects.create(short_name="Dev", description="d")
+
+        mail.outbox.clear()
+        result = send_volunteer_cancelled_emails_task(
+            volunteer_profile.id, [team.id], [role.id]
+        )
+        assert "Sent volunteer cancellation emails" in result
+        # confirmation to the volunteer + notification to the team lead
+        assert len(mail.outbox) >= 2
+
+    def test_cancelled_emails_not_found(self):
+        assert "not found" in send_volunteer_cancelled_emails_task(99999, [], [])

--- a/volunteer/forms.py
+++ b/volunteer/forms.py
@@ -10,13 +10,10 @@ from portal.models import Conference
 from portal.validators import validate_linked_in_pattern
 
 from .constants import ApplicationStatus
-from .models import (
-    Language,
-    Role,
-    Team,
-    VolunteerProfile,
-    send_internal_volunteer_onboarding_email,
-    send_volunteer_onboarding_email,
+from .models import Language, Role, Team, VolunteerProfile
+from .tasks import (
+    send_internal_volunteer_onboarding_email_task,
+    send_volunteer_onboarding_email_task,
 )
 
 
@@ -318,6 +315,6 @@ class VolunteerProfileReviewForm(ModelForm):
         volunteer_profile = super().save(commit)
 
         if newly_approved:
-            send_volunteer_onboarding_email(volunteer_profile)
-            send_internal_volunteer_onboarding_email(volunteer_profile)
+            send_volunteer_onboarding_email_task.delay(volunteer_profile.id)
+            send_internal_volunteer_onboarding_email_task.delay(volunteer_profile.id)
         return volunteer_profile

--- a/volunteer/models.py
+++ b/volunteer/models.py
@@ -456,11 +456,10 @@ def send_volunteer_cancelled_emails(instance, teams_before_cancel, roles_before_
 def volunteer_profile_signal(sender, instance, created, **kwargs):
     """Things to do whenever a volunteer profile is created or updated.
 
-    Send a notification email to the user to confirm their volunteer application status.
+    Queue a background task to notify the user (and the internal team on
+    creation) about their volunteer application status.
     """
-    if created:
-        send_internal_notification_email(instance)
-        send_volunteer_notification_email(instance)
-    else:
-        # no need to send email to internal team for VolunteerProfile updates (e.g. changing username, etc)
-        send_volunteer_notification_email(instance, updated=True)
+    # Local import avoids a circular import (tasks imports this module).
+    from .tasks import send_volunteer_profile_emails_task
+
+    send_volunteer_profile_emails_task.delay(instance.id, created)

--- a/volunteer/tasks.py
+++ b/volunteer/tasks.py
@@ -1,0 +1,71 @@
+from celery import shared_task
+
+from .models import (
+    Role,
+    Team,
+    VolunteerProfile,
+    send_internal_notification_email,
+    send_internal_volunteer_onboarding_email,
+    send_volunteer_cancelled_emails,
+    send_volunteer_notification_email,
+    send_volunteer_onboarding_email,
+)
+
+
+def _get_profile(profile_id):
+    try:
+        return VolunteerProfile.objects.get(id=profile_id)
+    except VolunteerProfile.DoesNotExist:
+        return None
+
+
+@shared_task(bind=True, max_retries=3, default_retry_delay=60)
+def send_volunteer_profile_emails_task(self, profile_id, created):
+    """Notify the applicant (and the internal team on creation) when a
+    volunteer profile is created or updated."""
+    profile = _get_profile(profile_id)
+    if profile is None:
+        return f"VolunteerProfile with id {profile_id} not found"
+    if created:
+        send_internal_notification_email(profile)
+        send_volunteer_notification_email(profile)
+    else:
+        send_volunteer_notification_email(profile, updated=True)
+    return f"Sent volunteer profile emails for {profile_id}"
+
+
+@shared_task(bind=True, max_retries=3, default_retry_delay=60)
+def send_volunteer_onboarding_email_task(self, profile_id):
+    """Send the onboarding email to an approved volunteer."""
+    profile = _get_profile(profile_id)
+    if profile is None:
+        return f"VolunteerProfile with id {profile_id} not found"
+    send_volunteer_onboarding_email(profile)
+    return f"Sent volunteer onboarding email for {profile_id}"
+
+
+@shared_task(bind=True, max_retries=3, default_retry_delay=60)
+def send_internal_volunteer_onboarding_email_task(self, profile_id):
+    """Notify the internal team to complete onboarding for an approved
+    volunteer."""
+    profile = _get_profile(profile_id)
+    if profile is None:
+        return f"VolunteerProfile with id {profile_id} not found"
+    send_internal_volunteer_onboarding_email(profile)
+    return f"Sent internal volunteer onboarding email for {profile_id}"
+
+
+@shared_task(bind=True, max_retries=3, default_retry_delay=60)
+def send_volunteer_cancelled_emails_task(self, profile_id, team_ids, role_ids):
+    """Notify the volunteer and affected team leads about a cancellation.
+
+    The teams/roles were removed from the profile before this runs, but the
+    Team/Role rows persist, so they are re-fetched by id.
+    """
+    profile = _get_profile(profile_id)
+    if profile is None:
+        return f"VolunteerProfile with id {profile_id} not found"
+    teams = list(Team.objects.filter(id__in=team_ids))
+    roles = list(Role.objects.filter(id__in=role_ids))
+    send_volunteer_cancelled_emails(profile, teams, roles)
+    return f"Sent volunteer cancellation emails for {profile_id}"

--- a/volunteer/views.py
+++ b/volunteer/views.py
@@ -22,8 +22,10 @@ from .models import (  # Language,
     PyladiesChapter,
     Team,
     VolunteerProfile,
-    send_volunteer_cancelled_emails,
-    send_volunteer_onboarding_email,
+)
+from .tasks import (
+    send_volunteer_cancelled_emails_task,
+    send_volunteer_onboarding_email_task,
 )
 
 
@@ -337,7 +339,7 @@ class ResendOnboardingEmailView(VolunteerAdminRequiredMixin, View):
         try:
             profile = VolunteerProfile.objects.get(pk=pk)
             if profile.application_status == ApplicationStatus.APPROVED:
-                send_volunteer_onboarding_email(profile)
+                send_volunteer_onboarding_email_task.delay(profile.id)
                 messages.add_message(
                     request, messages.SUCCESS, "Onboarding email was sent successfully."
                 )
@@ -378,18 +380,18 @@ class CancelVolunteeringView(VolunteerOrAdminRequiredMixin, View):
                 )
                 return redirect("volunteer:volunteer_profile_detail", pk=pk)
 
-            # Store team and role information before clearing for email notifications
-            teams_before_cancel = list(profile.teams.all())
-            roles_before_cancel = list(profile.roles.all())
+            # Capture team/role ids before clearing; the task re-fetches them
+            # for the notification emails (the rows persist, only membership
+            # is removed).
+            team_ids = list(profile.teams.values_list("id", flat=True))
+            role_ids = list(profile.roles.values_list("id", flat=True))
             # Update the volunteer profile
             profile.application_status = ApplicationStatus.CANCELLED
             profile.teams.clear()  # Remove from all teams
             profile.roles.clear()  # Remove from all roles
             profile.save()
 
-            send_volunteer_cancelled_emails(
-                profile, teams_before_cancel, roles_before_cancel
-            )
+            send_volunteer_cancelled_emails_task.delay(profile.id, team_ids, role_ids)
 
             messages.add_message(
                 request,


### PR DESCRIPTION
Completes **#242** by making the **volunteer** emails async too — mirroring the sponsorship setup merged in #302. With this, every email our app sends from a signal/view goes through Celery instead of blocking the request.

## What changed
- **`volunteer/tasks.py`** (new) — id-based tasks (re-fetch + retry, same shape as the sponsorship tasks) wrapping the existing email senders:
  - `send_volunteer_profile_emails_task` — applicant + internal notifications on create/update
  - `send_volunteer_onboarding_email_task` — applicant onboarding (approval / resend)
  - `send_internal_volunteer_onboarding_email_task` — internal team onboarding
  - `send_volunteer_cancelled_emails_task` — volunteer + team-lead cancellation notices
- **Triggers now `.delay()`**: the `post_save` signal, the review-form approval (`VolunteerProfileReviewForm.save`), the resend-onboarding view, and the cancel-volunteering view.
- **Cancellation**: the view captures team/role **ids** before clearing membership; the task re-fetches them (the `Team`/`Role` rows persist) for the notification emails.
- The existing email-sender functions are unchanged — the tasks just wrap them, so behavior is identical.

## Tests
- Runs under `CELERY_TASK_ALWAYS_EAGER` (from #302), so all existing signal/form/view email assertions still hold.
- Added `tests/volunteer/test_tasks.py` (success + not-found per task).
- **407 pass, 100% coverage**; black/isort/flake8 clean; no schema change.

## Scope
Covers all app-triggered emails (volunteer + sponsorship). allauth's own account emails (verification/reset) are framework-internal and out of scope for #242.

Closes #242