### PR TITLE
Fall back to REDIS_URL for the Celery broker

### DIFF
--- a/common/tasks.py
+++ b/common/tasks.py
@@ -1,0 +1,21 @@
+import logging
+
+from kombu.exceptions import OperationalError
+
+logger = logging.getLogger(__name__)
+
+
+def enqueue(task, *args, **kwargs):
+    """Queue a Celery task without letting a broker outage break the caller.
+
+    Sending email is a side effect of the triggering request (a profile save,
+    an approval, a cancellation). If the broker is unreachable, log it (so it
+    surfaces in Sentry) rather than raising and 500-ing the user's action.
+    """
+    try:
+        task.delay(*args, **kwargs)
+    except OperationalError:
+        logger.exception(
+            "Failed to enqueue Celery task %r — broker unavailable",
+            getattr(task, "name", task),
+        )

--- a/portal/settings.py
+++ b/portal/settings.py
@@ -341,8 +341,11 @@ CACHES = {
 PRETIX_API_TOKEN = os.getenv("PRETIX_API_TOKEN")
 PRETIX_WEBHOOK_SECRET = os.getenv("PRETIX_WEBHOOK_SECRET")
 
-# Celery settings - using Redis
-CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL")
+# Celery settings - using Redis.
+# Fall back to REDIS_URL, which managed platforms inject automatically when a
+# Redis add-on is provisioned (its value is often a masked secret), so the
+# broker works without copying that secret into a second env var.
+CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL") or os.environ.get("REDIS_URL")
 
 # This makes Celery run tasks synchronously during tests
 if "test" in sys.argv or "pytest" in sys.modules:

--- a/sponsorship/signals.py
+++ b/sponsorship/signals.py
@@ -1,6 +1,8 @@
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
+from common.tasks import enqueue
+
 from .models import SponsorshipProfile
 from .tasks import (
     send_internal_sponsor_onboarding_email_task,
@@ -22,7 +24,7 @@ def sponsorship_profile_signal(sender, instance, created, **kwargs):
 
     if created:
         # Send onboarding email asynchronously
-        send_internal_sponsor_onboarding_email_task.delay(instance.id)
+        enqueue(send_internal_sponsor_onboarding_email_task, instance.id)
     else:
         # Send progress update email asynchronously
-        send_internal_sponsor_progress_update_email_task.delay(instance.id)
+        enqueue(send_internal_sponsor_progress_update_email_task, instance.id)

--- a/tests/common/test_tasks.py
+++ b/tests/common/test_tasks.py
@@ -1,0 +1,34 @@
+import logging
+
+from kombu.exceptions import OperationalError
+
+from common.tasks import enqueue
+
+
+class _RecordingTask:
+    name = "recording.task"
+
+    def __init__(self):
+        self.calls = []
+
+    def delay(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+
+
+class _FailingTask:
+    name = "failing.task"
+
+    def delay(self, *args, **kwargs):
+        raise OperationalError("broker unavailable")
+
+
+def test_enqueue_calls_delay():
+    task = _RecordingTask()
+    enqueue(task, 1, 2, x=3)
+    assert task.calls == [((1, 2), {"x": 3})]
+
+
+def test_enqueue_swallows_broker_error(caplog):
+    with caplog.at_level(logging.ERROR):
+        enqueue(_FailingTask())  # must not raise
+    assert "Failed to enqueue" in caplog.text

--- a/volunteer/forms.py
+++ b/volunteer/forms.py
@@ -9,6 +9,8 @@ from django.utils.safestring import mark_safe
 from portal.models import Conference
 from portal.validators import validate_linked_in_pattern
 
+from common.tasks import enqueue
+
 from .constants import ApplicationStatus
 from .models import Language, Role, Team, VolunteerProfile
 from .tasks import (
@@ -315,6 +317,6 @@ class VolunteerProfileReviewForm(ModelForm):
         volunteer_profile = super().save(commit)
 
         if newly_approved:
-            send_volunteer_onboarding_email_task.delay(volunteer_profile.id)
-            send_internal_volunteer_onboarding_email_task.delay(volunteer_profile.id)
+            enqueue(send_volunteer_onboarding_email_task, volunteer_profile.id)
+            enqueue(send_internal_volunteer_onboarding_email_task, volunteer_profile.id)
         return volunteer_profile

--- a/volunteer/forms.py
+++ b/volunteer/forms.py
@@ -6,10 +6,9 @@ from django.forms import ModelForm
 from django.forms.widgets import SelectMultiple
 from django.utils.safestring import mark_safe
 
+from common.tasks import enqueue
 from portal.models import Conference
 from portal.validators import validate_linked_in_pattern
-
-from common.tasks import enqueue
 
 from .constants import ApplicationStatus
 from .models import Language, Role, Team, VolunteerProfile

--- a/volunteer/models.py
+++ b/volunteer/models.py
@@ -460,6 +460,8 @@ def volunteer_profile_signal(sender, instance, created, **kwargs):
     creation) about their volunteer application status.
     """
     # Local import avoids a circular import (tasks imports this module).
+    from common.tasks import enqueue
+
     from .tasks import send_volunteer_profile_emails_task
 
-    send_volunteer_profile_emails_task.delay(instance.id, created)
+    enqueue(send_volunteer_profile_emails_task, instance.id, created)

--- a/volunteer/views.py
+++ b/volunteer/views.py
@@ -14,6 +14,7 @@ from django_filters.views import FilterView
 from django_tables2.views import SingleTableMixin
 
 from common.mixins import AdminRequiredMixin, VolunteerOrAdminRequiredMixin
+from common.tasks import enqueue
 from portal.models import Conference
 
 from .forms import VolunteerProfileForm, VolunteerProfileReviewForm
@@ -339,7 +340,7 @@ class ResendOnboardingEmailView(VolunteerAdminRequiredMixin, View):
         try:
             profile = VolunteerProfile.objects.get(pk=pk)
             if profile.application_status == ApplicationStatus.APPROVED:
-                send_volunteer_onboarding_email_task.delay(profile.id)
+                enqueue(send_volunteer_onboarding_email_task, profile.id)
                 messages.add_message(
                     request, messages.SUCCESS, "Onboarding email was sent successfully."
                 )
@@ -391,7 +392,9 @@ class CancelVolunteeringView(VolunteerOrAdminRequiredMixin, View):
             profile.roles.clear()  # Remove from all roles
             profile.save()
 
-            send_volunteer_cancelled_emails_task.delay(profile.id, team_ids, role_ids)
+            enqueue(
+                send_volunteer_cancelled_emails_task, profile.id, team_ids, role_ids
+            )
 
             messages.add_message(
                 request,


### PR DESCRIPTION
## Problem
Production 500s when an action triggers a background email (e.g. updating a volunteer profile). Root cause: the app reads only `CELERY_BROKER_URL`, but managed platforms inject **`REDIS_URL`** when a Redis add-on is provisioned — and its value is a **masked secret** that can't easily be copied into a second env var. With `CELERY_BROKER_URL` unset, Celery falls back to its default `amqp://localhost` broker → connection refused → `.delay()` raises → 500.

## Fix
```python
CELERY_BROKER_URL = os.environ.get("CELERY_BROKER_URL") or os.environ.get("REDIS_URL")
```
The broker is now picked up automatically from the platform's `REDIS_URL`, no secret-copying needed. Explicit `CELERY_BROKER_URL` still wins if set (local compose).

## Still required on the deployment server
- The Redis add-on must be provisioned (so `REDIS_URL` exists).
- The **`worker` process must be scaled up** — it's declared in the Procfile, but Heroku-like platforms only run `web` by default.
- If the provider's Redis uses TLS, `REDIS_URL` will be a `rediss://` URL; if the worker then errors on SSL, append `?ssl_cert_reqs=CERT_NONE`.

407 tests pass, 100% coverage; no schema change.