### PR TITLE
Make stats aggregations conference-aware (Multi-year #7a)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -69,6 +69,8 @@ def conference(request):
         slug="2025",
         is_active=True,
         pretix_event_slug="2025",
+        sponsorship_goal=15000,
+        donation_goal=2500,
     )
 
 

--- a/portal/common.py
+++ b/portal/common.py
@@ -34,14 +34,13 @@ from portal.constants import (
     CACHE_KEY_VOLUNTEER_ONBOARDED_COUNT,
     CACHE_KEY_VOLUNTEER_PYLADIES_CHAPTERS,
     CACHE_KEY_VOLUNTEER_SIGNUPS_COUNT,
-    DONATION_GOAL_AMOUNT,
     DONATIONS_GOAL,
     HISTORICAL_STATS,
     PROPOSALS_2025_COUNT,
     SPONSORSHIP_GOAL,
-    SPONSORSHIP_GOAL_AMOUNT,
     STATS_CACHE_TIMEOUT,
 )
+from portal.models import Conference
 from sponsorship.models import (
     IndividualDonation,
     SponsorshipProfile,
@@ -51,116 +50,133 @@ from volunteer.constants import ApplicationStatus
 from volunteer.models import Team, VolunteerProfile
 
 
-def get_stats_cached_values():
+def get_stats_cached_values(conference=None):
     """Collect some stats and return them in a dictionary."""
+    if conference is None:
+        conference = Conference.get_active()
     stats_dict = {}
 
-    stats_dict.update(get_volunteer_stats_dict())
+    stats_dict.update(get_volunteer_stats_dict(conference))
 
-    stats_dict.update(get_sponsorships_stats_dict())
-    stats_dict.update(get_donations_stats_dict())
-    stats_dict.update(get_attendee_stats_dict())
+    stats_dict.update(get_sponsorships_stats_dict(conference))
+    stats_dict.update(get_donations_stats_dict(conference))
+    stats_dict.update(get_attendee_stats_dict(conference))
     stats_dict[CACHE_KEY_HISTORICAL_COMPARISON] = get_historical_comparison_data()
     return stats_dict
 
 
-def get_volunteer_stats_dict():
+def get_volunteer_stats_dict(conference):
     stats_dict = {}
-    stats_dict[CACHE_KEY_VOLUNTEER_SIGNUPS_COUNT] = get_volunteer_signup_stat_cache()
+    stats_dict[CACHE_KEY_VOLUNTEER_SIGNUPS_COUNT] = get_volunteer_signup_stat_cache(
+        conference
+    )
     stats_dict[CACHE_KEY_VOLUNTEER_ONBOARDED_COUNT] = (
-        get_volunteer_onboarded_stat_cache()
+        get_volunteer_onboarded_stat_cache(conference)
     )
-    stats_dict[CACHE_KEY_TEAMS_COUNT] = get_volunteer_teams_stat_cache()
-    stats_dict[CACHE_KEY_VOLUNTEER_LANGUAGES] = get_volunteer_languages_stat_cache()
+    stats_dict[CACHE_KEY_TEAMS_COUNT] = get_volunteer_teams_stat_cache(conference)
+    stats_dict[CACHE_KEY_VOLUNTEER_LANGUAGES] = get_volunteer_languages_stat_cache(
+        conference
+    )
     stats_dict[CACHE_KEY_VOLUNTEER_PYLADIES_CHAPTERS] = (
-        get_volunteer_pyladies_chapters_stat_cache()
+        get_volunteer_pyladies_chapters_stat_cache(conference)
     )
-    stats_dict[CACHE_KEY_VOLUNTEER_BREAKDOWN] = get_volunteer_breakdown()
+    stats_dict[CACHE_KEY_VOLUNTEER_BREAKDOWN] = get_volunteer_breakdown(conference)
     return stats_dict
 
 
-def get_sponsorships_stats_dict():
+def get_sponsorships_stats_dict(conference):
     stats_dict = {}
-    stats_dict[SPONSORSHIP_GOAL] = SPONSORSHIP_GOAL_AMOUNT
-    stats_dict[CACHE_KEY_TOTAL_SPONSORSHIPS] = get_sponsorship_total_count_stats_cache()
-    stats_dict[CACHE_KEY_SPONSORSHIP_PAID] = get_sponsorship_paid_amount_stats_cache()
-    stats_dict[CACHE_KEY_SPONSORSHIP_PAID_PERCENT] = (
-        get_sponsorship_paid_percent_cache()
+    stats_dict[SPONSORSHIP_GOAL] = conference.sponsorship_goal
+    stats_dict[CACHE_KEY_TOTAL_SPONSORSHIPS] = get_sponsorship_total_count_stats_cache(
+        conference
+    )
+    stats_dict[CACHE_KEY_SPONSORSHIP_PAID] = get_sponsorship_paid_amount_stats_cache(
+        conference
+    )
+    stats_dict[CACHE_KEY_SPONSORSHIP_PAID_PERCENT] = get_sponsorship_paid_percent_cache(
+        conference
     )
     stats_dict[CACHE_KEY_SPONSORSHIP_TOWARDS_GOAL_PERCENT] = (
-        get_sponsorship_to_goal_percent_cache()
+        get_sponsorship_to_goal_percent_cache(conference)
     )
 
     stats_dict[CACHE_KEY_SPONSORSHIP_PENDING] = (
-        get_sponsorship_pending_amount_stats_cache()
+        get_sponsorship_pending_amount_stats_cache(conference)
     )
     stats_dict[CACHE_KEY_SPONSORSHIP_COMMITTED] = (
-        get_sponsorship_committed_amount_stats_cache()
+        get_sponsorship_committed_amount_stats_cache(conference)
     )
     stats_dict[CACHE_KEY_SPONSORSHIP_PAID_COUNT] = (
-        get_sponsorship_paid_count_stats_cache()
+        get_sponsorship_paid_count_stats_cache(conference)
     )
     stats_dict[CACHE_KEY_SPONSORSHIP_PENDING_COUNT] = (
-        get_sponsorship_pending_count_stats_cache()
+        get_sponsorship_pending_count_stats_cache(conference)
     )
     stats_dict[CACHE_KEY_SPONSORSHIP_COMMITTED_COUNT] = (
-        get_sponsorship_committed_count_stats_cache()
+        get_sponsorship_committed_count_stats_cache(conference)
     )
-    stats_dict[CACHE_KEY_SPONSORSHIP_BREAKDOWN] = get_sponsorship_breakdown()
-    stats_dict[CACHE_KEY_TOTAL_FUNDS_RAISED] = (
-        get_total_donations_amount_cache()
-        + get_sponsorship_committed_amount_stats_cache()
-    )
+    stats_dict[CACHE_KEY_SPONSORSHIP_BREAKDOWN] = get_sponsorship_breakdown(conference)
+    stats_dict[CACHE_KEY_TOTAL_FUNDS_RAISED] = get_total_donations_amount_cache(
+        conference
+    ) + get_sponsorship_committed_amount_stats_cache(conference)
     return stats_dict
 
 
-def get_volunteer_signup_stat_cache():
+def get_volunteer_signup_stat_cache(conference):
     """Returns the cached count of volunteer signups."""
-    volunteer_signups_count = cache.get(CACHE_KEY_VOLUNTEER_SIGNUPS_COUNT)
+    cache_key = f"{CACHE_KEY_VOLUNTEER_SIGNUPS_COUNT}_{conference.year}"
+    volunteer_signups_count = cache.get(cache_key)
     if not volunteer_signups_count:
-        volunteer_signups_count = VolunteerProfile.objects.count()
+        volunteer_signups_count = VolunteerProfile.objects.filter(
+            conference=conference
+        ).count()
         cache.set(
-            CACHE_KEY_VOLUNTEER_SIGNUPS_COUNT,
+            cache_key,
             volunteer_signups_count,
             STATS_CACHE_TIMEOUT,
         )
     return volunteer_signups_count
 
 
-def get_volunteer_onboarded_stat_cache():
+def get_volunteer_onboarded_stat_cache(conference):
     """Returns the cached count of volunteers onboarded."""
-    volunteer_onboarded_count = cache.get(CACHE_KEY_VOLUNTEER_ONBOARDED_COUNT)
+    cache_key = f"{CACHE_KEY_VOLUNTEER_ONBOARDED_COUNT}_{conference.year}"
+    volunteer_onboarded_count = cache.get(cache_key)
     if not volunteer_onboarded_count:
         volunteer_onboarded_count = VolunteerProfile.objects.filter(
-            application_status=ApplicationStatus.APPROVED.value
+            application_status=ApplicationStatus.APPROVED.value, conference=conference
         ).count()
         cache.set(
-            CACHE_KEY_VOLUNTEER_ONBOARDED_COUNT,
+            cache_key,
             volunteer_onboarded_count,
             STATS_CACHE_TIMEOUT,
         )
     return volunteer_onboarded_count
 
 
-def get_volunteer_teams_stat_cache():
+def get_volunteer_teams_stat_cache(conference):
     """Returns the cached count of volunteer teams."""
-    volunteer_teams_count = cache.get(CACHE_KEY_TEAMS_COUNT)
+    cache_key = f"{CACHE_KEY_TEAMS_COUNT}_{conference.year}"
+    volunteer_teams_count = cache.get(cache_key)
     if not volunteer_teams_count:
-        volunteer_teams_count = Team.objects.count()
+        volunteer_teams_count = Team.objects.filter(conference=conference).count()
         cache.set(
-            CACHE_KEY_TEAMS_COUNT,
+            cache_key,
             volunteer_teams_count,
             STATS_CACHE_TIMEOUT,
         )
     return volunteer_teams_count
 
 
-def get_volunteer_languages_stat_cache():
+def get_volunteer_languages_stat_cache(conference):
     """Returns the cached count of volunteer languages."""
-    volunteer_languages_count = cache.get(CACHE_KEY_VOLUNTEER_LANGUAGES)
+    cache_key = f"{CACHE_KEY_VOLUNTEER_LANGUAGES}_{conference.year}"
+    volunteer_languages_count = cache.get(cache_key)
     if not volunteer_languages_count:
         volunteer_languages_qs = (
-            VolunteerProfile.objects.filter(language__isnull=False)
+            VolunteerProfile.objects.filter(
+                language__isnull=False, conference=conference
+            )
             .distinct()
             .select_related("language")
         )
@@ -168,21 +184,22 @@ def get_volunteer_languages_stat_cache():
             "language__id"
         ).count()
         cache.set(
-            CACHE_KEY_VOLUNTEER_LANGUAGES,
+            cache_key,
             volunteer_languages_count,
             STATS_CACHE_TIMEOUT,
         )
     return volunteer_languages_count
 
 
-def get_volunteer_pyladies_chapters_stat_cache():
-    volunteer_pyladies_chapters_count = cache.get(CACHE_KEY_VOLUNTEER_PYLADIES_CHAPTERS)
+def get_volunteer_pyladies_chapters_stat_cache(conference):
+    cache_key = f"{CACHE_KEY_VOLUNTEER_PYLADIES_CHAPTERS}_{conference.year}"
+    volunteer_pyladies_chapters_count = cache.get(cache_key)
     if not volunteer_pyladies_chapters_count:
         volunteer_pyladies_chapters_count = VolunteerProfile.objects.filter(
-            chapter__isnull=False
+            chapter__isnull=False, conference=conference
         ).count()
         cache.set(
-            CACHE_KEY_VOLUNTEER_PYLADIES_CHAPTERS,
+            cache_key,
             volunteer_pyladies_chapters_count,
             STATS_CACHE_TIMEOUT,
         )
@@ -206,24 +223,27 @@ SPONSOR_PENDING_STATUS = [
 ]
 
 
-def get_sponsorship_total_count_stats_cache():
+def get_sponsorship_total_count_stats_cache(conference):
     """Returns total sponsorship count"""
-    sponsorship_count = cache.get(CACHE_KEY_TOTAL_SPONSORSHIPS)
+    cache_key = f"{CACHE_KEY_TOTAL_SPONSORSHIPS}_{conference.year}"
+    sponsorship_count = cache.get(cache_key)
     if not sponsorship_count:
         sponsorship_count = SponsorshipProfile.objects.filter(
-            progress_status__gt=SponsorshipProgressStatus.NOT_CONTACTED
+            progress_status__gt=SponsorshipProgressStatus.NOT_CONTACTED,
+            conference=conference,
         ).count()
-        cache.set(CACHE_KEY_TOTAL_SPONSORSHIPS, sponsorship_count, STATS_CACHE_TIMEOUT)
+        cache.set(cache_key, sponsorship_count, STATS_CACHE_TIMEOUT)
     return sponsorship_count
 
 
-def get_sponsorship_paid_amount_stats_cache():
+def get_sponsorship_paid_amount_stats_cache(conference):
     """Returns total sponsorship paid amount"""
-    cache.delete(CACHE_KEY_SPONSORSHIP_PAID)
-    total_paid = cache.get(CACHE_KEY_SPONSORSHIP_PAID)
+    cache_key = f"{CACHE_KEY_SPONSORSHIP_PAID}_{conference.year}"
+    cache.delete(cache_key)
+    total_paid = cache.get(cache_key)
     if not total_paid:
         paid_sponsors = SponsorshipProfile.objects.filter(
-            progress_status=SponsorshipProgressStatus.PAID
+            progress_status=SponsorshipProgressStatus.PAID, conference=conference
         )
         paid_sponsors_no_override_qs = paid_sponsors.filter(
             sponsorship_override_amount__isnull=True, sponsorship_tier__isnull=False
@@ -248,16 +268,17 @@ def get_sponsorship_paid_amount_stats_cache():
 
         total_paid = paid_sponsors_no_override + paid_sponsors_with_override
         total_paid = total_paid
-        cache.set(CACHE_KEY_SPONSORSHIP_PAID, total_paid, STATS_CACHE_TIMEOUT)
+        cache.set(cache_key, total_paid, STATS_CACHE_TIMEOUT)
     return total_paid
 
 
-def get_sponsorship_pending_amount_stats_cache():
+def get_sponsorship_pending_amount_stats_cache(conference):
     """Returns total sponsorship pending amount"""
-    total_pending = cache.get(CACHE_KEY_SPONSORSHIP_PENDING)
+    cache_key = f"{CACHE_KEY_SPONSORSHIP_PENDING}_{conference.year}"
+    total_pending = cache.get(cache_key)
     if not total_pending:
         pending_sponsors = SponsorshipProfile.objects.filter(
-            progress_status__in=SPONSOR_PENDING_STATUS
+            progress_status__in=SPONSOR_PENDING_STATUS, conference=conference
         )
         pending_sponsors_no_override_qs = pending_sponsors.filter(
             sponsorship_override_amount__isnull=True, sponsorship_tier__isnull=False
@@ -284,16 +305,17 @@ def get_sponsorship_pending_amount_stats_cache():
         total_pending = pending_sponsors_no_override + pending_sponsors_with_override
         total_pending = total_pending
 
-    cache.set(CACHE_KEY_SPONSORSHIP_PENDING, total_pending, STATS_CACHE_TIMEOUT)
+    cache.set(cache_key, total_pending, STATS_CACHE_TIMEOUT)
     return total_pending
 
 
-def get_sponsorship_committed_amount_stats_cache():
+def get_sponsorship_committed_amount_stats_cache(conference):
     """Returns total sponsorship committed amount"""
-    total_committed = cache.get(CACHE_KEY_SPONSORSHIP_COMMITTED)
+    cache_key = f"{CACHE_KEY_SPONSORSHIP_COMMITTED}_{conference.year}"
+    total_committed = cache.get(cache_key)
     if not total_committed:
         committed_sponsors = SponsorshipProfile.objects.filter(
-            progress_status__in=SPONSOR_COMMITTED_STATUS
+            progress_status__in=SPONSOR_COMMITTED_STATUS, conference=conference
         )
         committed_sponsors_no_override_qs = committed_sponsors.filter(
             sponsorship_override_amount__isnull=True, sponsorship_tier__isnull=False
@@ -322,102 +344,107 @@ def get_sponsorship_committed_amount_stats_cache():
             committed_sponsors_no_override + committed_sponsors_with_override
         )
         total_committed = total_committed
-        cache.set(CACHE_KEY_SPONSORSHIP_COMMITTED, total_committed, STATS_CACHE_TIMEOUT)
+        cache.set(cache_key, total_committed, STATS_CACHE_TIMEOUT)
     return total_committed
 
 
-def get_sponsorship_paid_count_stats_cache():
+def get_sponsorship_paid_count_stats_cache(conference):
     """Returns sponsorship paid count"""
-    sponsorship_paid_count = cache.get(CACHE_KEY_SPONSORSHIP_PAID_COUNT)
+    cache_key = f"{CACHE_KEY_SPONSORSHIP_PAID_COUNT}_{conference.year}"
+    sponsorship_paid_count = cache.get(cache_key)
     if not sponsorship_paid_count:
         sponsorship_paid_count = SponsorshipProfile.objects.filter(
-            progress_status=SponsorshipProgressStatus.PAID
+            progress_status=SponsorshipProgressStatus.PAID, conference=conference
         ).count()
         cache.set(
-            CACHE_KEY_SPONSORSHIP_PAID_COUNT,
+            cache_key,
             sponsorship_paid_count,
             STATS_CACHE_TIMEOUT,
         )
     return sponsorship_paid_count
 
 
-def get_sponsorship_pending_count_stats_cache():
+def get_sponsorship_pending_count_stats_cache(conference):
     """Returns sponsorship pending count"""
-    sponsorship_pending_count = cache.get(CACHE_KEY_SPONSORSHIP_PENDING_COUNT)
+    cache_key = f"{CACHE_KEY_SPONSORSHIP_PENDING_COUNT}_{conference.year}"
+    sponsorship_pending_count = cache.get(cache_key)
     if not sponsorship_pending_count:
         sponsorship_pending_count = SponsorshipProfile.objects.filter(
-            progress_status__in=SPONSOR_PENDING_STATUS
+            progress_status__in=SPONSOR_PENDING_STATUS, conference=conference
         ).count()
         cache.set(
-            CACHE_KEY_SPONSORSHIP_PENDING_COUNT,
+            cache_key,
             sponsorship_pending_count,
             STATS_CACHE_TIMEOUT,
         )
     return sponsorship_pending_count
 
 
-def get_sponsorship_committed_count_stats_cache():
+def get_sponsorship_committed_count_stats_cache(conference):
     """Returns sponsorship committed count"""
-    sponsorship_committed_count = cache.get(CACHE_KEY_SPONSORSHIP_COMMITTED_COUNT)
+    cache_key = f"{CACHE_KEY_SPONSORSHIP_COMMITTED_COUNT}_{conference.year}"
+    sponsorship_committed_count = cache.get(cache_key)
     if not sponsorship_committed_count:
         sponsorship_committed_count = SponsorshipProfile.objects.filter(
-            progress_status__in=SPONSOR_COMMITTED_STATUS
+            progress_status__in=SPONSOR_COMMITTED_STATUS, conference=conference
         ).count()
         cache.set(
-            CACHE_KEY_SPONSORSHIP_COMMITTED_COUNT,
+            cache_key,
             sponsorship_committed_count,
             STATS_CACHE_TIMEOUT,
         )
     return sponsorship_committed_count
 
 
-def get_sponsorship_to_goal_percent_cache():
+def get_sponsorship_to_goal_percent_cache(conference):
     """Returns sponsorship towards goal percent"""
-    sponsorship_towards_goal_percent = cache.get(
-        CACHE_KEY_SPONSORSHIP_TOWARDS_GOAL_PERCENT
-    )
+    cache_key = f"{CACHE_KEY_SPONSORSHIP_TOWARDS_GOAL_PERCENT}_{conference.year}"
+    sponsorship_towards_goal_percent = cache.get(cache_key)
     if not sponsorship_towards_goal_percent:
-        total_paid = get_sponsorship_paid_amount_stats_cache()
+        total_paid = get_sponsorship_paid_amount_stats_cache(conference)
         sponsorship_towards_goal_percent = (
-            (total_paid / SPONSORSHIP_GOAL_AMOUNT) * 100
-            if SPONSORSHIP_GOAL_AMOUNT > 0
+            (total_paid / conference.sponsorship_goal) * 100
+            if conference.sponsorship_goal > 0
             else 0
         )
         cache.set(
-            CACHE_KEY_SPONSORSHIP_TOWARDS_GOAL_PERCENT,
+            cache_key,
             sponsorship_towards_goal_percent,
             STATS_CACHE_TIMEOUT,
         )
     return sponsorship_towards_goal_percent
 
 
-def get_sponsorship_paid_percent_cache():
+def get_sponsorship_paid_percent_cache(conference):
     """Returns sponsorship paid percent"""
-    sponsorship_paid_percent = cache.get(CACHE_KEY_SPONSORSHIP_PAID_PERCENT)
+    cache_key = f"{CACHE_KEY_SPONSORSHIP_PAID_PERCENT}_{conference.year}"
+    sponsorship_paid_percent = cache.get(cache_key)
     if not sponsorship_paid_percent:
-        total_sponsorships = get_sponsorship_committed_amount_stats_cache()
-        total_paid_sponsorships = get_sponsorship_paid_amount_stats_cache()
+        total_sponsorships = get_sponsorship_committed_amount_stats_cache(conference)
+        total_paid_sponsorships = get_sponsorship_paid_amount_stats_cache(conference)
         sponsorship_paid_percent = (
             (total_paid_sponsorships / total_sponsorships) * 100
             if total_sponsorships > 0
             else 0
         )
         cache.set(
-            CACHE_KEY_SPONSORSHIP_PAID_PERCENT,
+            cache_key,
             sponsorship_paid_percent,
             STATS_CACHE_TIMEOUT,
         )
     return sponsorship_paid_percent
 
 
-def get_sponsorship_breakdown():
-    sponsorship_breakdown = cache.get(CACHE_KEY_SPONSORSHIP_BREAKDOWN)
+def get_sponsorship_breakdown(conference):
+    cache_key = f"{CACHE_KEY_SPONSORSHIP_BREAKDOWN}_{conference.year}"
+    sponsorship_breakdown = cache.get(cache_key)
     if not sponsorship_breakdown:
         sponsorship_breakdown = []
 
         # Breakdown by Status
         sponsors = SponsorshipProfile.objects.filter(
-            progress_status__gt=SponsorshipProgressStatus.NOT_CONTACTED
+            progress_status__gt=SponsorshipProgressStatus.NOT_CONTACTED,
+            conference=conference,
         ).select_related("sponsorship_tier")
         sponsors_by_status = sponsors.values("progress_status").annotate(
             count=Count("id")
@@ -454,24 +481,25 @@ def get_sponsorship_breakdown():
         )
 
         cache.set(
-            CACHE_KEY_SPONSORSHIP_BREAKDOWN,
+            cache_key,
             sponsorship_breakdown,
             STATS_CACHE_TIMEOUT,
         )
     return sponsorship_breakdown
 
 
-def get_volunteer_breakdown():
+def get_volunteer_breakdown(conference):
     """Returns the volunteer breakdown stats"""
-    volunteer_breakdown = cache.get(CACHE_KEY_VOLUNTEER_BREAKDOWN)
+    cache_key = f"{CACHE_KEY_VOLUNTEER_BREAKDOWN}_{conference.year}"
+    volunteer_breakdown = cache.get(cache_key)
 
     if not volunteer_breakdown:
         volunteer_breakdown = []
 
         # Breakdown by chapter
-        volunteers = VolunteerProfile.objects.all().select_related(
-            "chapter", "region", "language"
-        )
+        volunteers = VolunteerProfile.objects.filter(
+            conference=conference
+        ).select_related("chapter", "region", "language")
         volunteers_by_chapter = (
             volunteers.filter(chapter__isnull=False)
             .values("chapter__chapter_description")
@@ -525,110 +553,119 @@ def get_volunteer_breakdown():
         )
 
         cache.set(
-            CACHE_KEY_VOLUNTEER_BREAKDOWN,
+            cache_key,
             volunteer_breakdown,
             STATS_CACHE_TIMEOUT,
         )
     return volunteer_breakdown
 
 
-def get_total_donations_amount_cache():
+def get_total_donations_amount_cache(conference):
     """Returns the donations amount"""
-    total_donations = cache.get(CACHE_KEY_DONATIONS_TOTAL_AMOUNT)
+    cache_key = f"{CACHE_KEY_DONATIONS_TOTAL_AMOUNT}_{conference.year}"
+    total_donations = cache.get(cache_key)
     if not total_donations:
 
         individual_donations = (
-            IndividualDonation.objects.aggregate(Sum("donation_amount"))[
-                "donation_amount__sum"
-            ]
+            IndividualDonation.objects.filter(conference=conference).aggregate(
+                Sum("donation_amount")
+            )["donation_amount__sum"]
             or 0
         )
         donations_from_pretix = (
-            PretixOrder.objects.filter(status=PretixOrderstatus.PAID).aggregate(
-                Sum("total")
-            )["total__sum"]
+            PretixOrder.objects.filter(
+                status=PretixOrderstatus.PAID, conference=conference
+            ).aggregate(Sum("total"))["total__sum"]
             or 0
         )
         total_donations = individual_donations + donations_from_pretix
         cache.set(
-            CACHE_KEY_DONATIONS_TOTAL_AMOUNT,
+            cache_key,
             total_donations,
             STATS_CACHE_TIMEOUT,
         )
     return total_donations
 
 
-def get_donors_count_cache():
+def get_donors_count_cache(conference):
     """Returns the number of unique donors"""
-    donors_count = cache.get(CACHE_KEY_DONORS_COUNT)
+    cache_key = f"{CACHE_KEY_DONORS_COUNT}_{conference.year}"
+    donors_count = cache.get(cache_key)
     if not donors_count:
 
         individual_donors_count = (
-            IndividualDonation.objects.values("donor_email").distinct().count()
+            IndividualDonation.objects.filter(conference=conference)
+            .values("donor_email")
+            .distinct()
+            .count()
         )
         pretix_donors_count = PretixOrder.objects.filter(
-            status=PretixOrderstatus.PAID, total__gt=0
+            status=PretixOrderstatus.PAID, total__gt=0, conference=conference
         ).count()
         donors_count = individual_donors_count + pretix_donors_count
         cache.set(
-            CACHE_KEY_DONORS_COUNT,
+            cache_key,
             donors_count,
             STATS_CACHE_TIMEOUT,
         )
     return donors_count
 
 
-def get_donation_to_goal_percent_cache():
+def get_donation_to_goal_percent_cache(conference):
     """Returns donation towards goal percent"""
-    donation_towards_goal_percent = cache.get(CACHE_KEY_DONATION_TOWARDS_GOAL_PERCENT)
+    cache_key = f"{CACHE_KEY_DONATION_TOWARDS_GOAL_PERCENT}_{conference.year}"
+    donation_towards_goal_percent = cache.get(cache_key)
     if not donation_towards_goal_percent:
-        total_donations = get_total_donations_amount_cache()
+        total_donations = get_total_donations_amount_cache(conference)
         donation_towards_goal_percent = (
-            (total_donations / DONATION_GOAL_AMOUNT) * 100
-            if DONATION_GOAL_AMOUNT > 0
+            (total_donations / conference.donation_goal) * 100
+            if conference.donation_goal > 0
             else 0
         )
         cache.set(
-            CACHE_KEY_DONATION_TOWARDS_GOAL_PERCENT,
+            cache_key,
             donation_towards_goal_percent,
             STATS_CACHE_TIMEOUT,
         )
     return donation_towards_goal_percent
 
 
-def get_donations_stats_dict():
+def get_donations_stats_dict(conference):
     stats_dict = {}
-    stats_dict[DONATIONS_GOAL] = DONATION_GOAL_AMOUNT
+    stats_dict[DONATIONS_GOAL] = conference.donation_goal
     stats_dict[CACHE_KEY_DONATION_BREAKDOWN] = {
-        "total_donations_amount": get_total_donations_amount_cache(),
-        "donors_count": get_donors_count_cache(),
-        "donation_towards_goal_percent": get_donation_to_goal_percent_cache(),
+        "total_donations_amount": get_total_donations_amount_cache(conference),
+        "donors_count": get_donors_count_cache(conference),
+        "donation_towards_goal_percent": get_donation_to_goal_percent_cache(conference),
     }
     return stats_dict
 
 
-def get_attendee_count_cache():
+def get_attendee_count_cache(conference):
     """Returns the attendee count"""
-    attendee_count = cache.get(CACHE_KEY_ATTENDEE_COUNT)
+    cache_key = f"{CACHE_KEY_ATTENDEE_COUNT}_{conference.year}"
+    attendee_count = cache.get(cache_key)
     if not attendee_count:
         attendee_count = PretixOrder.objects.filter(
-            status=PretixOrderstatus.PAID
+            status=PretixOrderstatus.PAID, conference=conference
         ).count()
         cache.set(
-            CACHE_KEY_ATTENDEE_COUNT,
+            cache_key,
             attendee_count,
             STATS_CACHE_TIMEOUT,
         )
     return attendee_count
 
 
-def get_attendee_stats_dict():
+def get_attendee_stats_dict(conference):
     stats_dict = {}
-    stats_dict[CACHE_KEY_ATTENDEE_COUNT] = get_attendee_count_cache()
-    stats_dict[CACHE_KEY_ATTENDEE_BREAKDOWN] = get_attendee_breakdown()
-    stats_dict[CACHE_KEY_ATTENDEE_FIRST_TIME_COUNT] = get_first_time_attendee_count()
-    stats_dict[CACHE_KEY_ATTENDEE_FIRST_TIME_PERCENT] = (
-        get_first_time_attendee_percent()
+    stats_dict[CACHE_KEY_ATTENDEE_COUNT] = get_attendee_count_cache(conference)
+    stats_dict[CACHE_KEY_ATTENDEE_BREAKDOWN] = get_attendee_breakdown(conference)
+    stats_dict[CACHE_KEY_ATTENDEE_FIRST_TIME_COUNT] = get_first_time_attendee_count(
+        conference
+    )
+    stats_dict[CACHE_KEY_ATTENDEE_FIRST_TIME_PERCENT] = get_first_time_attendee_percent(
+        conference
     )
 
     return stats_dict
@@ -669,31 +706,34 @@ def get_attendee_current_position_breakdown(attendee_profiles):
     return current_position_breakdown
 
 
-def get_first_time_attendee_count():
+def get_first_time_attendee_count(conference):
     """Returns the count of first-time attendees."""
-    first_time_attendee_count = cache.get(CACHE_KEY_ATTENDEE_FIRST_TIME_COUNT)
+    cache_key = f"{CACHE_KEY_ATTENDEE_FIRST_TIME_COUNT}_{conference.year}"
+    first_time_attendee_count = cache.get(cache_key)
     if not first_time_attendee_count:
         first_time_attendee_count = AttendeeProfile.objects.filter(
             order__status=PretixOrderstatus.PAID,
             participated_in_previous_event__contains=[
                 PARTICIPATED_IN_PREVIOUS_EVENT_CHOICES[2][0]
             ],
+            order__conference=conference,
         ).count()
 
         cache.set(
-            CACHE_KEY_ATTENDEE_FIRST_TIME_COUNT,
+            cache_key,
             first_time_attendee_count,
             STATS_CACHE_TIMEOUT,
         )
     return first_time_attendee_count
 
 
-def get_first_time_attendee_percent():
+def get_first_time_attendee_percent(conference):
     """Returns the percent of first-time attendees."""
-    first_time_attendee_percent = cache.get(CACHE_KEY_ATTENDEE_FIRST_TIME_PERCENT)
+    cache_key = f"{CACHE_KEY_ATTENDEE_FIRST_TIME_PERCENT}_{conference.year}"
+    first_time_attendee_percent = cache.get(cache_key)
     if not first_time_attendee_percent:
-        attendee_total_count = get_attendee_count_cache()
-        attendee_first_time_count = get_first_time_attendee_count()
+        attendee_total_count = get_attendee_count_cache(conference)
+        attendee_first_time_count = get_first_time_attendee_count(conference)
         first_time_attendee_percent = (
             (attendee_first_time_count / attendee_total_count) * 100
             if attendee_total_count > 0
@@ -701,20 +741,22 @@ def get_first_time_attendee_percent():
         )
 
         cache.set(
-            CACHE_KEY_ATTENDEE_FIRST_TIME_PERCENT,
+            cache_key,
             first_time_attendee_percent,
             STATS_CACHE_TIMEOUT,
         )
     return first_time_attendee_percent
 
 
-def get_attendee_breakdown():
+def get_attendee_breakdown(conference):
     """Returns the attendee demographic breakdown stats."""
-    attendee_breakdown = cache.get(CACHE_KEY_ATTENDEE_BREAKDOWN)
+    cache_key = f"{CACHE_KEY_ATTENDEE_BREAKDOWN}_{conference.year}"
+    attendee_breakdown = cache.get(cache_key)
     if not attendee_breakdown:
         attendee_breakdown = []
         attendee_profiles = AttendeeProfile.objects.filter(
             order__status=PretixOrderstatus.PAID,
+            order__conference=conference,
         )
         attendee_breakdown.append(
             {
@@ -730,7 +772,7 @@ def get_attendee_breakdown():
         )
 
         cache.set(
-            CACHE_KEY_ATTENDEE_BREAKDOWN,
+            cache_key,
             attendee_breakdown,
             STATS_CACHE_TIMEOUT,
         )
@@ -745,11 +787,17 @@ def get_historical_comparison_data():
     historical_comparison = cache.get(CACHE_KEY_HISTORICAL_COMPARISON)
     if not historical_comparison:
         # Get current year data
-        current_registrations = get_attendee_count_cache()
-        current_sponsors = get_sponsorship_committed_count_stats_cache()
-        current_sponsorship_amount = get_sponsorship_committed_amount_stats_cache()
-        current_donors = get_donors_count_cache()
-        current_donation_amount = get_total_donations_amount_cache()
+        current_registrations = get_attendee_count_cache(Conference.get_active())
+        current_sponsors = get_sponsorship_committed_count_stats_cache(
+            Conference.get_active()
+        )
+        current_sponsorship_amount = get_sponsorship_committed_amount_stats_cache(
+            Conference.get_active()
+        )
+        current_donors = get_donors_count_cache(Conference.get_active())
+        current_donation_amount = get_total_donations_amount_cache(
+            Conference.get_active()
+        )
 
         # Build comparison data structure
         historical_comparison = []

--- a/sponsorship/views.py
+++ b/sponsorship/views.py
@@ -257,7 +257,7 @@ class SponsorshipProfileList(CanViewSponsorship, SingleTableMixin, FilterView):
         ).first()
         context["volunteer_profile"] = volunteer_profile
         context["title"] = "Sponsorship Profiles"
-        context["stats"] = get_sponsorships_stats_dict()
+        context["stats"] = get_sponsorships_stats_dict(Conference.get_active())
         context["conferences"] = self.viewable_conferences()
         context["selected_conference"] = self.get_selected_conference()
         return context

--- a/tests/portal/test_common.py
+++ b/tests/portal/test_common.py
@@ -40,10 +40,10 @@ class TestGetStatsCachedValues:
     def test_get_volunteer_signup_stat_cache(self, conference):
         """Test that the volunteer signup count is cached and returned correctly."""
 
-        cache_key = CACHE_KEY_VOLUNTEER_SIGNUPS_COUNT
+        cache_key = f"{CACHE_KEY_VOLUNTEER_SIGNUPS_COUNT}_{conference.year}"
         cache.delete(cache_key)
 
-        result = get_volunteer_signup_stat_cache()
+        result = get_volunteer_signup_stat_cache(conference)
         assert result == 0
         cache.delete(cache_key)
 
@@ -56,16 +56,16 @@ class TestGetStatsCachedValues:
             conference=conference,
         )
 
-        result = get_volunteer_signup_stat_cache()
+        result = get_volunteer_signup_stat_cache(conference)
         assert result == 2
 
     def test_get_stats_cached_values(self, conference):
         """Test that the stats dictionary contains the volunteer signup count."""
 
-        cache_key = CACHE_KEY_VOLUNTEER_SIGNUPS_COUNT
+        cache_key = f"{CACHE_KEY_VOLUNTEER_SIGNUPS_COUNT}_{conference.year}"
         cache.delete(cache_key)
 
-        stats = get_stats_cached_values()
+        stats = get_stats_cached_values(conference)
         assert stats[CACHE_KEY_VOLUNTEER_SIGNUPS_COUNT] == 0
         cache.delete(cache_key)
 
@@ -78,16 +78,16 @@ class TestGetStatsCachedValues:
             conference=conference,
         )
 
-        result = get_stats_cached_values()
+        result = get_stats_cached_values(conference)
         assert result.get(CACHE_KEY_VOLUNTEER_SIGNUPS_COUNT) == 2
 
     def test_get_sponsorship_total_counts_stats_does_not_count_not_contacted(
         self, conference
     ):
-        cache_key = CACHE_KEY_TOTAL_SPONSORSHIPS
+        cache_key = f"{CACHE_KEY_TOTAL_SPONSORSHIPS}_{conference.year}"
         cache.delete(cache_key)
 
-        stats = get_stats_cached_values()
+        stats = get_stats_cached_values(conference)
         assert stats[CACHE_KEY_TOTAL_SPONSORSHIPS] == 0
         cache.delete(cache_key)
 
@@ -106,14 +106,14 @@ class TestGetStatsCachedValues:
             conference=conference,
         )
 
-        result = get_sponsorship_total_count_stats_cache()
+        result = get_sponsorship_total_count_stats_cache(conference)
         assert result == 2
 
     def test_get_sponsorship_paid_amount_stats_cache(self, conference):
-        cache_key = CACHE_KEY_SPONSORSHIP_PAID
+        cache_key = f"{CACHE_KEY_SPONSORSHIP_PAID}_{conference.year}"
         cache.delete(cache_key)
 
-        stats = get_stats_cached_values()
+        stats = get_stats_cached_values(conference)
         assert stats[CACHE_KEY_SPONSORSHIP_PAID] == 0
         cache.delete(cache_key)
         tier_1 = SponsorshipTier.objects.create(
@@ -134,14 +134,14 @@ class TestGetStatsCachedValues:
             conference=conference,
         )
 
-        result = get_sponsorship_paid_amount_stats_cache()
+        result = get_sponsorship_paid_amount_stats_cache(conference)
         assert result == 1900
 
     def test_get_sponsorship_pending_amount_stats_cache(self, conference):
-        cache_key = CACHE_KEY_SPONSORSHIP_PENDING
+        cache_key = f"{CACHE_KEY_SPONSORSHIP_PENDING}_{conference.year}"
         cache.delete(cache_key)
 
-        stats = get_stats_cached_values()
+        stats = get_stats_cached_values(conference)
         assert stats[CACHE_KEY_SPONSORSHIP_PENDING] == 0
         cache.delete(cache_key)
         tier_1 = SponsorshipTier.objects.create(
@@ -162,14 +162,14 @@ class TestGetStatsCachedValues:
             conference=conference,
         )
 
-        result = get_sponsorship_pending_amount_stats_cache()
+        result = get_sponsorship_pending_amount_stats_cache(conference)
         assert result == 1900
 
     def test_get_sponsorship_committed_amount_stats_cache(self, conference):
-        cache_key = CACHE_KEY_SPONSORSHIP_COMMITTED
+        cache_key = f"{CACHE_KEY_SPONSORSHIP_COMMITTED}_{conference.year}"
         cache.delete(cache_key)
 
-        stats = get_stats_cached_values()
+        stats = get_stats_cached_values(conference)
         assert stats[CACHE_KEY_SPONSORSHIP_COMMITTED] == 0
         cache.delete(cache_key)
         tier_1 = SponsorshipTier.objects.create(
@@ -190,14 +190,14 @@ class TestGetStatsCachedValues:
             conference=conference,
         )
 
-        result = get_sponsorship_committed_amount_stats_cache()
+        result = get_sponsorship_committed_amount_stats_cache(conference)
         assert result == 1900
 
     def test_get_sponsorship_pending_count_stats_cache(self, conference):
-        cache_key = CACHE_KEY_SPONSORSHIP_PENDING_COUNT
+        cache_key = f"{CACHE_KEY_SPONSORSHIP_PENDING_COUNT}_{conference.year}"
         cache.delete(cache_key)
 
-        stats = get_stats_cached_values()
+        stats = get_stats_cached_values(conference)
         assert stats[CACHE_KEY_SPONSORSHIP_PENDING_COUNT] == 0
         cache.delete(cache_key)
         tier_1 = SponsorshipTier.objects.create(
@@ -218,14 +218,14 @@ class TestGetStatsCachedValues:
             conference=conference,
         )
 
-        result = get_sponsorship_pending_count_stats_cache()
+        result = get_sponsorship_pending_count_stats_cache(conference)
         assert result == 2
 
     def test_get_sponsorship_committed_count_stats_cache(self, conference):
-        cache_key = CACHE_KEY_SPONSORSHIP_COMMITTED_COUNT
+        cache_key = f"{CACHE_KEY_SPONSORSHIP_COMMITTED_COUNT}_{conference.year}"
         cache.delete(cache_key)
 
-        stats = get_stats_cached_values()
+        stats = get_stats_cached_values(conference)
         assert stats[CACHE_KEY_SPONSORSHIP_COMMITTED_COUNT] == 0
         cache.delete(cache_key)
         tier_1 = SponsorshipTier.objects.create(
@@ -246,14 +246,14 @@ class TestGetStatsCachedValues:
             conference=conference,
         )
 
-        result = get_sponsorship_committed_count_stats_cache()
+        result = get_sponsorship_committed_count_stats_cache(conference)
         assert result == 2
 
     def test_get_sponsorship_paid_percent_cache(self, conference):
-        cache_key = CACHE_KEY_SPONSORSHIP_PAID_PERCENT
+        cache_key = f"{CACHE_KEY_SPONSORSHIP_PAID_PERCENT}_{conference.year}"
         cache.delete(cache_key)
 
-        stats = get_sponsorship_paid_percent_cache()
+        stats = get_sponsorship_paid_percent_cache(conference)
         assert stats == 0
         cache.delete(cache_key)
 
@@ -273,14 +273,14 @@ class TestGetStatsCachedValues:
             conference=conference,
         )
 
-        result = get_sponsorship_paid_percent_cache()
+        result = get_sponsorship_paid_percent_cache(conference)
         assert result == 50
 
     def test_get_sponsorship_to_goal_percent_cache(self, conference):
-        cache_key = CACHE_KEY_SPONSORSHIP_TOWARDS_GOAL_PERCENT
+        cache_key = f"{CACHE_KEY_SPONSORSHIP_TOWARDS_GOAL_PERCENT}_{conference.year}"
         cache.delete(cache_key)
 
-        stats = get_sponsorship_to_goal_percent_cache()
+        stats = get_sponsorship_to_goal_percent_cache(conference)
         assert stats == 0
         cache.delete(cache_key)
 
@@ -306,7 +306,7 @@ class TestGetStatsCachedValues:
             conference=conference,
         )
 
-        result = get_sponsorship_to_goal_percent_cache()
+        result = get_sponsorship_to_goal_percent_cache(conference)
         assert result == 20
 
 
@@ -382,7 +382,7 @@ class TestAttendeeStats:
             current_position=["Manager"],
         )
 
-        breakdown = get_attendee_breakdown()
+        breakdown = get_attendee_breakdown(conference)
         for b in breakdown:
             if b["title"] == "Current Position":
                 assert b["data"] == [
@@ -397,10 +397,10 @@ class TestAttendeeStats:
                     ["Junior", 1],
                 ]
 
-    def test_attendee_breakdown_with_no_profiles(self):
+    def test_attendee_breakdown_with_no_profiles(self, conference):
         """Test attendee breakdown returns empty when no profiles exist."""
         from portal.common import get_attendee_breakdown
 
-        breakdown = get_attendee_breakdown()
+        breakdown = get_attendee_breakdown(conference)
         for b in breakdown:
             assert b["data"] == []


### PR DESCRIPTION
**Phase 7a — the foundation of the stats refactor.** Makes every statistic year-aware internally, with **no UX change yet** (`?year=` switching is 7b; manage-list stats are 7c).

## What changed
- Every aggregation/cache function and dict-builder in `portal/common.py` takes a **`conference`** argument, **filters its query** by it (attendees via `order__conference`), and **caches under a per-year key** (`f"{KEY}_{year}"`).
- **Goals come from the `Conference`** (`sponsorship_goal`/`donation_goal`) instead of the `*_GOAL_AMOUNT` constants (now unused there).
- `get_stats_cached_values(conference=None)` defaults to the **active** conference.
- `get_historical_comparison_data()` stays the cross-year comparison (Phase 8 owns it) — it passes the active conference to its sub-calls so it keeps working.

## Callers (no behavior change)
- `portal/views.py` stats/stats_json/index still call `get_stats_cached_values()` → active.
- `sponsorship/views.py` list passes the active conference (its year tab gets wired in **7c**).

## Tests
- `tests/portal/test_common.py` threads the conference through every call + namespaces direct cache-key access.
- conftest's active conference now sets `sponsorship_goal=15000` / `donation_goal=2500` (matching the 2025 backfill) so goal/percent assertions are unchanged.
- **409 pass, 100% coverage**; black/isort/flake8 clean; `makemigrations --check` clean (no schema change).

## Follow-ups
- **7b** — `?year=` on the public `/stats/` page + year switcher + `historical_snapshot` fallback for 2023/24.
- **7c** — wire the volunteer/sponsor/attendee manage-list embedded stats to their year tabs (fixes the sponsor-list overview).

Refs #321