### PR TITLE
Year switcher + historical fallback on the public stats page (Multi-year #7b)

### DIFF
--- a/portal/views.py
+++ b/portal/views.py
@@ -34,13 +34,31 @@ def index(request):
     return render(request, "portal/index.html", context)
 
 
+def _stats_conference(request):
+    """Resolve the conference to show stats for from ``?year=``.
+
+    Falls back to the active conference when no (valid) year is given.
+    """
+    year = request.GET.get("year")
+    if year:
+        conference = Conference.objects.filter(year=year).first()
+        if conference is not None:
+            return conference
+    return Conference.get_active()
+
+
 def stats(request):
     """
     Show Interesting Public Stats
     """
-    context = {}
-
-    context["stats"] = get_stats_cached_values()
+    conference = _stats_conference(request)
+    context = {
+        "stats": get_stats_cached_values(conference),
+        "conferences": Conference.objects.all(),
+        "selected_conference": conference,
+        # Years that predate the portal have no live data, only a snapshot.
+        "historical_snapshot": conference.historical_snapshot if conference else None,
+    }
 
     return render(request, "portal/stats.html", context)
 
@@ -51,7 +69,7 @@ def stats_json(request):
     """
     context = {}
 
-    context["stats"] = get_stats_cached_values()
+    context["stats"] = get_stats_cached_values(_stats_conference(request))
 
     return JsonResponse(context)
 

--- a/templates/portal/stats.html
+++ b/templates/portal/stats.html
@@ -9,8 +9,10 @@
     google.charts.load('current', { 'packages': ['corechart', 'bar'] });
     google.charts.setOnLoadCallback(drawChart);
     function drawChart() {
+        {% if not historical_snapshot %}
         {% include "sponsorship/sponsorship_charts.html" %}
         {% include "volunteer/volunteer_charts.html" %}
+        {% endif %}
         {% include "portal/historical_comparison_charts.html" %}
    }
     </script>
@@ -25,55 +27,150 @@
 {% block content %}
     <div class="container px-4 py-3" id="featured-3">
         <h2 class="pb-2 border-bottom">
-            PyLadiesCon Stats and Numbers
+            PyLadiesCon Stats and Numbers — {{ selected_conference.year }}
         </h2>
-        <div class="alert alert-success" role="alert">
-            <h4 class="alert-heading">
-                Live conference stats*
-            </h4>
-            <p class="mb-0">
-                Our stats are also available as a <a href="{% url 'portal_stats_json' %}">JSON endpoint</a> so that you can come up with your own visualization and dashboard.
-            </p>
-            <p class="mb-0">
-                View the <a href="{% url 'dashboard_gallery' %}">Dashboard Gallery</a> to see what others have built using our data!
-            </p>
-            <hr>
-            <p>
-                <span class="text-muted">*Up to 5 minutes delay.</span>
-            </p>
-        </div>
-        {% include "sponsorship/sponsorship_stats.html" %}
-        <!-- Sponsor/Donate Callout -->
-        <div class="container border rounded-3 p-4 mb-4 bg-light">
-            <div class="row align-items-center">
-                <div class="col-md-8">
-                    <h3 class="mb-2">
-                        Support PyLadiesCon!
-                    </h3>
-                    <p class="mb-0 text-muted">
-                        Help us make PyLadiesCon possible by becoming a sponsor or making a donation.
-                        Your support enables us to create an inclusive and accessible conference for the global PyLadies
-                        community.
-                    </p>
+        {% if conferences %}
+            <div class="btn-group mb-3" role="group" aria-label="Conference year">
+                {% for conference in conferences %}
+                    <a href="?year={{ conference.year }}"
+                       class="btn btn-sm {% if conference == selected_conference %}btn-primary{% else %}btn-outline-primary{% endif %}">
+                        {{ conference.year }}
+                    </a>
+                {% endfor %}
+            </div>
+        {% endif %}
+        {% if historical_snapshot %}
+            <div class="alert alert-info" role="alert">
+                <h4 class="alert-heading">
+                    Limited data
+                </h4>
+                <p class="mb-0">
+                    {{ selected_conference }} predates this portal — showing the recorded summary numbers.
+                </p>
+            </div>
+            <div class="row g-3 mb-4 row-cols-2 row-cols-md-3">
+                <div class="col">
+                    <div class="card h-100 text-center">
+                        <div class="card-body">
+                            <h3 class="card-title">
+                                {{ historical_snapshot.registrations }}
+                            </h3>
+                            <p class="card-text text-muted mb-0">
+                                Registrations
+                            </p>
+                        </div>
+                    </div>
                 </div>
-                <div class="col-md-4 text-md-end mt-3 mt-md-0">
-                    <a href="https://2025.conference.pyladies.com/en/sponsors/"
-                       target="_blank"
-                       rel="noopener noreferrer"
-                       class="btn btn-primary btn-lg me-2 mb-2">
-                        <i class="bi bi-building"></i> Sponsor Us
-                    </a>
-                    <a href="https://2025.conference.pyladies.com/en/donate/"
-                       target="_blank"
-                       rel="noopener noreferrer"
-                       class="btn btn-success btn-lg mb-2">
-                        <i class="bi bi-heart-fill"></i> Donate
-                    </a>
+                <div class="col">
+                    <div class="card h-100 text-center">
+                        <div class="card-body">
+                            <h3 class="card-title">
+                                {{ selected_conference.proposals_count }}
+                            </h3>
+                            <p class="card-text text-muted mb-0">
+                                Proposals
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="col">
+                    <div class="card h-100 text-center">
+                        <div class="card-body">
+                            <h3 class="card-title">
+                                {{ historical_snapshot.sponsors }}
+                            </h3>
+                            <p class="card-text text-muted mb-0">
+                                Sponsors
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="col">
+                    <div class="card h-100 text-center">
+                        <div class="card-body">
+                            <h3 class="card-title">
+                                ${{ historical_snapshot.sponsorship_amount }}
+                            </h3>
+                            <p class="card-text text-muted mb-0">
+                                Sponsorship Amount
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="col">
+                    <div class="card h-100 text-center">
+                        <div class="card-body">
+                            <h3 class="card-title">
+                                {{ historical_snapshot.donors }}
+                            </h3>
+                            <p class="card-text text-muted mb-0">
+                                Donors
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="col">
+                    <div class="card h-100 text-center">
+                        <div class="card-body">
+                            <h3 class="card-title">
+                                ${{ historical_snapshot.donation_amount }}
+                            </h3>
+                            <p class="card-text text-muted mb-0">
+                                Donations
+                            </p>
+                        </div>
+                    </div>
                 </div>
             </div>
-        </div>
-        {% include "volunteer/volunteer_stats.html" %}
-        {% include "attendee/attendee_stats.html" %}
+        {% else %}
+            <div class="alert alert-success" role="alert">
+                <h4 class="alert-heading">
+                    Live conference stats*
+                </h4>
+                <p class="mb-0">
+                    Our stats are also available as a <a href="{% url 'portal_stats_json' %}">JSON endpoint</a> so that you can come up with your own visualization and dashboard.
+                </p>
+                <p class="mb-0">
+                    View the <a href="{% url 'dashboard_gallery' %}">Dashboard Gallery</a> to see what others have built using our data!
+                </p>
+                <hr>
+                <p>
+                    <span class="text-muted">*Up to 5 minutes delay.</span>
+                </p>
+            </div>
+            {% include "sponsorship/sponsorship_stats.html" %}
+            <!-- Sponsor/Donate Callout -->
+            <div class="container border rounded-3 p-4 mb-4 bg-light">
+                <div class="row align-items-center">
+                    <div class="col-md-8">
+                        <h3 class="mb-2">
+                            Support PyLadiesCon!
+                        </h3>
+                        <p class="mb-0 text-muted">
+                            Help us make PyLadiesCon possible by becoming a sponsor or making a donation.
+                            Your support enables us to create an inclusive and accessible conference for the global PyLadies
+                            community.
+                        </p>
+                    </div>
+                    <div class="col-md-4 text-md-end mt-3 mt-md-0">
+                        <a href="https://2025.conference.pyladies.com/en/sponsors/"
+                           target="_blank"
+                           rel="noopener noreferrer"
+                           class="btn btn-primary btn-lg me-2 mb-2">
+                            <i class="bi bi-building"></i> Sponsor Us
+                        </a>
+                        <a href="https://2025.conference.pyladies.com/en/donate/"
+                           target="_blank"
+                           rel="noopener noreferrer"
+                           class="btn btn-success btn-lg mb-2">
+                            <i class="bi bi-heart-fill"></i> Donate
+                        </a>
+                    </div>
+                </div>
+            </div>
+            {% include "volunteer/volunteer_stats.html" %}
+            {% include "attendee/attendee_stats.html" %}
+        {% endif %}
         <!-- Historical Comparison Section -->
         <div class="row mt-5">
             <div class="col-12">

--- a/tests/portal/test_views.py
+++ b/tests/portal/test_views.py
@@ -2,6 +2,7 @@ import pytest
 from django.urls import reverse
 from pytest_django.asserts import assertRedirects
 
+from portal.models import Conference
 from portal_account.models import PortalProfile
 from volunteer.models import PyladiesChapter
 
@@ -45,6 +46,45 @@ class TestPortalStats:
         assert response.status_code == 200
         assert "PyLadiesCon Stats" in response.content.decode()
 
+    def test_stats_defaults_to_active_conference(self, client, conference):
+        response = client.get(reverse("portal_stats"))
+        assert response.status_code == 200
+        assert response.context["selected_conference"] == conference
+
+    def test_stats_year_switcher_selects_requested_year(self, client, conference):
+        past = Conference.objects.create(
+            year=2024, name="PyLadiesCon 2024", slug="2024"
+        )
+        response = client.get(reverse("portal_stats") + "?year=2024")
+        assert response.status_code == 200
+        assert response.context["selected_conference"] == past
+
+    def test_stats_invalid_year_falls_back_to_active(self, client, conference):
+        response = client.get(reverse("portal_stats") + "?year=9999")
+        assert response.status_code == 200
+        assert response.context["selected_conference"] == conference
+
+    def test_stats_historical_year_renders_snapshot(self, client, conference):
+        Conference.objects.create(
+            year=2024,
+            name="PyLadiesCon 2024",
+            slug="2024",
+            proposals_count=164,
+            historical_snapshot={
+                "registrations": 600,
+                "sponsors": 8,
+                "sponsorship_amount": 10500,
+                "donors": 58,
+                "donation_amount": 650,
+            },
+        )
+        response = client.get(reverse("portal_stats") + "?year=2024")
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert "Limited data" in content
+        assert "600" in content  # snapshot registrations
+        assert "164" in content  # proposals_count
+
 
 @pytest.mark.django_db
 class TestPyladiesChapters:
@@ -86,6 +126,12 @@ class TestStatsJSON:
         assert response.status_code == 200
         data = response.json()
         assert "stats" in data
+
+    def test_stats_json_accepts_year(self, client, conference):
+        Conference.objects.create(year=2024, name="PyLadiesCon 2024", slug="2024")
+        response = client.get(reverse("portal_stats_json") + "?year=2024")
+        assert response.status_code == 200
+        assert "stats" in response.json()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
**Phase 7b** — makes the public `/stats/` page year-aware (builds on 7a's conference-aware aggregations).

## What changed
- **`portal/views.py`** — `_stats_conference()` resolves `?year=` (falls back to the active conference on missing/invalid year); `stats` and `stats_json` pass it to `get_stats_cached_values(conference)`. The page context gets the conference list, the selected conference, and its `historical_snapshot`.
- **`templates/portal/stats.html`** — a **year-switcher** button group; and for editions that **predate the portal** (non-empty `historical_snapshot`, i.e. 2023/2024) it renders the **snapshot summary cards + a "Limited data" banner** instead of an empty live dashboard, and skips the live chart JS so nothing errors.

## Tests
- `?year=` selects the right edition; invalid year falls back to active; default is active; historical year renders the snapshot + banner; `stats.json` accepts `?year=`.
- **414 pass, 100% coverage**; lint clean; no schema change.

## Follow-up
- **7c** — wire the volunteer/sponsor/attendee **manage-list** embedded stats to their year tabs (fixes the sponsor-list overview).

Refs #321