### PR TITLE
Sponsor-list stats follow the selected year tab (Multi-year #7c)

### DIFF
--- a/sponsorship/views.py
+++ b/sponsorship/views.py
@@ -252,14 +252,20 @@ class SponsorshipProfileList(CanViewSponsorship, SingleTableMixin, FilterView):
     def get_context_data(self, **kwargs):
         # kwargs.pop('filter')
         context = super().get_context_data(**kwargs)
+        selected_conference = self.get_selected_conference()
         volunteer_profile = VolunteerProfile.objects.filter(
             user=self.request.user, conference=Conference.get_active()
         ).first()
         context["volunteer_profile"] = volunteer_profile
         context["title"] = "Sponsorship Profiles"
-        context["stats"] = get_sponsorships_stats_dict(Conference.get_active())
+        # Stats follow the selected year tab so the overview matches the list.
+        context["stats"] = (
+            get_sponsorships_stats_dict(selected_conference)
+            if selected_conference
+            else None
+        )
         context["conferences"] = self.viewable_conferences()
-        context["selected_conference"] = self.get_selected_conference()
+        context["selected_conference"] = selected_conference
         return context
 
 

--- a/tests/sponsorship/test_views.py
+++ b/tests/sponsorship/test_views.py
@@ -3,6 +3,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 from pytest_django.asserts import assertRedirects
 
+from portal.constants import SPONSORSHIP_GOAL
 from portal.models import Conference
 from sponsorship.models import (
     SponsorshipProfile,
@@ -45,6 +46,29 @@ class TestSponsorshipConferenceScoping:
         ]
         assert "Past Sponsor" in past_orgs
         assert "Active Sponsor" not in past_orgs
+
+    def test_stats_follow_selected_year(self, client, admin_user, conference):
+        past = Conference.objects.create(
+            year=2024, name="PyLadiesCon 2024", slug="2024", sponsorship_goal=9999
+        )
+        client.force_login(admin_user)
+        url = reverse("sponsorship:sponsorship_list")
+
+        # Default tab → the active conference's goal.
+        active_stats = client.get(url).context["stats"]
+        assert active_stats[SPONSORSHIP_GOAL] == conference.sponsorship_goal
+
+        # Switching the year tab → that conference's goal.
+        past_stats = client.get(f"{url}?conference={past.pk}").context["stats"]
+        assert past_stats[SPONSORSHIP_GOAL] == 9999
+
+    def test_stats_none_when_selected_conference_not_viewable(
+        self, client, admin_user, conference
+    ):
+        client.force_login(admin_user)
+        url = reverse("sponsorship:sponsorship_list")
+        response = client.get(f"{url}?conference=99999")
+        assert response.context["stats"] is None
 
     def test_volunteer_sees_only_the_year_they_are_approved_for(
         self, client, portal_user, conference


### PR DESCRIPTION
**Phase 7c — the final stats piece.** Fixes the **sponsor-list overview showing the wrong year** (the bug originally reported: switching the year tab changed the table but the stats kept showing the active year).

## What changed
- **`sponsorship/views.py`** — `SponsorshipProfileList` now builds the embedded stats from **`get_selected_conference()`** (the same conference driving the table) instead of the active conference. Guards the invalid-`?conference=` case (no viewable conference → `stats=None`, which the template renders blank).

## Why only the sponsor list
The `volunteer_stats.html` / `attendee_stats.html` blocks are included **only** on the public `/stats/` page (made year-aware in 7b). The **sponsor list** is the one manage page that embeds a stats block, so it's the only one needing this wiring.

## Tests
- Stats follow the selected year tab (active vs a 2024 edition with a distinct goal); `stats` is `None` when the selected conference isn't viewable.
- **416 pass, 100% coverage**; lint clean; no schema change.

## Phase 7 complete
With 7a (aggregations) + 7b (public page) + 7c (manage list), **all stats are now year-aware everywhere**.

Refs #321