### PR TITLE
Year-over-year comparison page from real per-year data (Multi-year #8)

### DIFF
--- a/portal/common.py
+++ b/portal/common.py
@@ -35,8 +35,6 @@ from portal.constants import (
     CACHE_KEY_VOLUNTEER_PYLADIES_CHAPTERS,
     CACHE_KEY_VOLUNTEER_SIGNUPS_COUNT,
     DONATIONS_GOAL,
-    HISTORICAL_STATS,
-    PROPOSALS_2025_COUNT,
     SPONSORSHIP_GOAL,
     STATS_CACHE_TIMEOUT,
 )
@@ -61,7 +59,6 @@ def get_stats_cached_values(conference=None):
     stats_dict.update(get_sponsorships_stats_dict(conference))
     stats_dict.update(get_donations_stats_dict(conference))
     stats_dict.update(get_attendee_stats_dict(conference))
-    stats_dict[CACHE_KEY_HISTORICAL_COMPARISON] = get_historical_comparison_data()
     return stats_dict
 
 
@@ -779,142 +776,71 @@ def get_attendee_breakdown(conference):
     return attendee_breakdown
 
 
-def get_historical_comparison_data():
+def _conference_comparison_metrics(conference):
+    """Per-year metrics for the comparison charts.
+
+    Editions that predate the portal carry only a ``historical_snapshot``;
+    everything else is aggregated live from that conference's records.
     """
-    Returns historical comparison data for charts showing progress over the years.
-    Combines hardcoded historical data with current year's data.
+    snapshot = conference.historical_snapshot
+    if snapshot:
+        sponsorship_amount = snapshot.get("sponsorship_amount", 0)
+        donation_amount = snapshot.get("donation_amount", 0)
+        metrics = {
+            "registrations": snapshot.get("registrations", 0),
+            "sponsors": snapshot.get("sponsors", 0),
+            "donors": snapshot.get("donors", 0),
+        }
+    else:
+        sponsorship_amount = get_sponsorship_committed_amount_stats_cache(conference)
+        donation_amount = get_total_donations_amount_cache(conference)
+        metrics = {
+            "registrations": get_attendee_count_cache(conference),
+            "sponsors": get_sponsorship_committed_count_stats_cache(conference),
+            "donors": get_donors_count_cache(conference),
+        }
+    metrics["sponsorship_amount"] = sponsorship_amount
+    metrics["donation_amount"] = donation_amount
+    metrics["proposals"] = conference.proposals_count
+    metrics["proceeds"] = sponsorship_amount + donation_amount
+    return metrics
+
+
+def get_historical_comparison_data():
+    """Year-over-year comparison charts built from every conference's data.
+
+    Each edition contributes one bar per chart, taken from its live stats or,
+    for editions that predate the portal, its ``historical_snapshot``.
     """
     historical_comparison = cache.get(CACHE_KEY_HISTORICAL_COMPARISON)
     if not historical_comparison:
-        # Get current year data
-        current_registrations = get_attendee_count_cache(Conference.get_active())
-        current_sponsors = get_sponsorship_committed_count_stats_cache(
-            Conference.get_active()
-        )
-        current_sponsorship_amount = get_sponsorship_committed_amount_stats_cache(
-            Conference.get_active()
-        )
-        current_donors = get_donors_count_cache(Conference.get_active())
-        current_donation_amount = get_total_donations_amount_cache(
-            Conference.get_active()
-        )
-
-        # Build comparison data structure
-        historical_comparison = []
-
-        # Registrations comparison
-        historical_comparison.append(
+        per_year = [
+            (str(conference.year), _conference_comparison_metrics(conference))
+            for conference in Conference.objects.order_by("year")
+        ]
+        charts = [
+            ("Registrations Over the Years", "Registrations", "registrations"),
+            ("Proposals Over the Years", "Proposals", "proposals"),
+            ("Number of Sponsors Over the Years", "Sponsors", "sponsors"),
+            (
+                "Sponsorship Amount Over the Years",
+                "Amount (USD)",
+                "sponsorship_amount",
+            ),
+            ("Number of Individual Donors Over the Years", "Donors", "donors"),
+            ("Donation Amount Over the Years", "Amount (USD)", "donation_amount"),
+            ("Total Proceeds Over the Years", "Amount (USD)", "proceeds"),
+        ]
+        historical_comparison = [
             {
-                "title": "Registrations Over the Years",
-                "columns": [["string", "Year"], ["number", "Registrations"]],
-                "data": [
-                    ["2023", HISTORICAL_STATS["2023"]["registrations"]],
-                    ["2024", HISTORICAL_STATS["2024"]["registrations"]],
-                    ["2025", current_registrations],
-                ],
-                "chart_id": "registrations_comparison",
+                "title": title,
+                "columns": [["string", "Year"], ["number", value_label]],
+                "data": [[year, metrics[key]] for year, metrics in per_year],
+                "chart_id": f"{key}_comparison",
                 "chart_type": "bar",
             }
-        )
-
-        # Proposals comparison
-        historical_comparison.append(
-            {
-                "title": "Proposals Over the Years",
-                "columns": [["string", "Year"], ["number", "Proposals"]],
-                "data": [
-                    ["2023", HISTORICAL_STATS["2023"]["proposals"]],
-                    ["2024", HISTORICAL_STATS["2024"]["proposals"]],
-                    ["2025", PROPOSALS_2025_COUNT],
-                ],
-                "chart_id": "proposals_comparison",
-                "chart_type": "bar",
-            }
-        )
-
-        # Sponsors comparison
-        historical_comparison.append(
-            {
-                "title": "Number of Sponsors Over the Years",
-                "columns": [["string", "Year"], ["number", "Sponsors"]],
-                "data": [
-                    ["2023", HISTORICAL_STATS["2023"]["sponsors"]],
-                    ["2024", HISTORICAL_STATS["2024"]["sponsors"]],
-                    ["2025", current_sponsors],
-                ],
-                "chart_id": "sponsors_comparison",
-                "chart_type": "bar",
-            }
-        )
-
-        # Sponsorship amount comparison
-        historical_comparison.append(
-            {
-                "title": "Sponsorship Amount Over the Years",
-                "columns": [["string", "Year"], ["number", "Amount (USD)"]],
-                "data": [
-                    ["2023", HISTORICAL_STATS["2023"]["sponsorship_amount"]],
-                    ["2024", HISTORICAL_STATS["2024"]["sponsorship_amount"]],
-                    ["2025", current_sponsorship_amount],
-                ],
-                "chart_id": "sponsorship_amount_comparison",
-                "chart_type": "bar",
-            }
-        )
-
-        # Individual donations comparison
-        historical_comparison.append(
-            {
-                "title": "Number of Individual Donors Over the Years",
-                "columns": [["string", "Year"], ["number", "Donors"]],
-                "data": [
-                    ["2023", HISTORICAL_STATS["2023"]["donors"]],
-                    ["2024", HISTORICAL_STATS["2024"]["donors"]],
-                    ["2025", current_donors],
-                ],
-                "chart_id": "donors_comparison",
-                "chart_type": "bar",
-            }
-        )
-
-        # Donation amount comparison
-        historical_comparison.append(
-            {
-                "title": "Donation Amount Over the Years",
-                "columns": [["string", "Year"], ["number", "Amount (USD)"]],
-                "data": [
-                    ["2023", HISTORICAL_STATS["2023"]["donation_amount"]],
-                    ["2024", HISTORICAL_STATS["2024"]["donation_amount"]],
-                    ["2025", current_donation_amount],
-                ],
-                "chart_id": "donation_amount_comparison",
-                "chart_type": "bar",
-            }
-        )
-
-        # Total proceeds comparison
-        historical_comparison.append(
-            {
-                "title": "Total Proceeds Over the Years",
-                "columns": [["string", "Year"], ["number", "Amount (USD)"]],
-                "data": [
-                    [
-                        "2023",
-                        HISTORICAL_STATS["2023"]["sponsorship_amount"]
-                        + HISTORICAL_STATS["2023"]["donation_amount"],
-                    ],
-                    [
-                        "2024",
-                        HISTORICAL_STATS["2024"]["sponsorship_amount"]
-                        + HISTORICAL_STATS["2024"]["donation_amount"],
-                    ],
-                    ["2025", current_sponsorship_amount + current_donation_amount],
-                ],
-                "chart_id": "proceeds_comparison",
-                "chart_type": "bar",
-            }
-        )
-
+            for title, value_label, key in charts
+        ]
         cache.set(
             CACHE_KEY_HISTORICAL_COMPARISON,
             historical_comparison,

--- a/portal/constants.py
+++ b/portal/constants.py
@@ -16,11 +16,9 @@ CACHE_KEY_SPONSORSHIP_COMMITTED_COUNT = "sponsorship_committed_count"
 CACHE_KEY_SPONSORSHIP_PAID_PERCENT = "sponsorship_paid_percent"
 CACHE_KEY_SPONSORSHIP_TOWARDS_GOAL_PERCENT = "sponsorship_towards_goal_percent"
 CACHE_KEY_SPONSORSHIP_BREAKDOWN = "sponsorship_breakdown"
-SPONSORSHIP_GOAL_AMOUNT = 15000
 
 CACHE_KEY_VOLUNTEER_BREAKDOWN = "volunteer_breakdown"
 
-DONATION_GOAL_AMOUNT = 2500
 CACHE_KEY_DONATION_BREAKDOWN = "donation_breakdown"
 CACHE_KEY_DONATIONS_TOTAL_AMOUNT = "donations_total_amount"
 CACHE_KEY_DONORS_COUNT = "donors_count"
@@ -45,29 +43,5 @@ CACHE_KEY_ATTENDEE_BY_REGION = "attendee_by_region"
 
 # Historical data for comparison charts
 CACHE_KEY_HISTORICAL_COMPARISON = "historical_comparison"
-
-# Historical data from past PyLadiesCon events
-# Data source: https://conference.pyladies.com/2024-pyladiescon-ends/
-HISTORICAL_STATS = {
-    "2023": {
-        "registrations": 600,
-        "proposals": 164,
-        "sponsors": 8,
-        "sponsorship_amount": 10500,
-        "donors": 58,
-        "donation_amount": 650,
-    },
-    "2024": {
-        "registrations": 732,
-        "proposals": 192,
-        "sponsors": 11,
-        "sponsorship_amount": 10000,
-        "donors": 105,
-        "donation_amount": 1520,
-    },
-}
-
-# Current year proposals count (not stored in database)
-PROPOSALS_2025_COUNT = 194
 
 BASE_PRETIX_URL = "https://pretix.eu/api/v1/"

--- a/portal/urls.py
+++ b/portal/urls.py
@@ -61,6 +61,11 @@ urlpatterns = [
         name="portal_stats_json",
     ),
     path(
+        "stats/comparison/",
+        views.stats_comparison,
+        name="portal_stats_comparison",
+    ),
+    path(
         "dashboard_gallery",
         views.dashboard_gallery,
         name="dashboard_gallery",

--- a/portal/views.py
+++ b/portal/views.py
@@ -2,7 +2,7 @@ from django.contrib.auth import get_user
 from django.http import JsonResponse
 from django.shortcuts import redirect, render
 
-from portal.common import get_stats_cached_values
+from portal.common import get_historical_comparison_data, get_stats_cached_values
 from portal.models import Conference
 from portal_account.models import PortalProfile
 from volunteer.models import VolunteerProfile
@@ -72,6 +72,15 @@ def stats_json(request):
     context["stats"] = get_stats_cached_values(_stats_conference(request))
 
     return JsonResponse(context)
+
+
+def stats_comparison(request):
+    """
+    Show year-over-year comparison charts across all conference editions.
+    """
+    context = {"historical_comparison": get_historical_comparison_data()}
+
+    return render(request, "portal/stats_comparison.html", context)
 
 
 def dashboard_gallery(request):

--- a/templates/portal/historical_comparison_charts.html
+++ b/templates/portal/historical_comparison_charts.html
@@ -1,8 +1,8 @@
 {% comment %}
 Historical comparison charts for PyLadiesCon stats across years
-Uses Google Charts to display bar charts comparing metrics from 2023, 2024, and 2025
+Uses Google Charts to display bar charts comparing metrics across all editions
 {% endcomment %}
-{% for comparison in stats.historical_comparison %}
+{% for comparison in historical_comparison %}
     var data_{{ comparison.chart_id }} = new google.visualization.DataTable();
     {% for column in comparison.columns %}
         data_{{ comparison.chart_id }}.addColumn('{{ column.0 }}', '{{ column.1 }}');

--- a/templates/portal/stats.html
+++ b/templates/portal/stats.html
@@ -13,7 +13,6 @@
         {% include "sponsorship/sponsorship_charts.html" %}
         {% include "volunteer/volunteer_charts.html" %}
         {% endif %}
-        {% include "portal/historical_comparison_charts.html" %}
    }
     </script>
     <style>
@@ -171,25 +170,16 @@
             {% include "volunteer/volunteer_stats.html" %}
             {% include "attendee/attendee_stats.html" %}
         {% endif %}
-        <!-- Historical Comparison Section -->
         <div class="row mt-5">
             <div class="col-12">
                 <h3 class="pb-2 border-bottom">
-                    <i class="bi bi-graph-up"></i> Historical Comparison
+                    <i class="bi bi-graph-up"></i> Year-over-Year Comparison
                 </h3>
+                <p>
+                    See how PyLadiesCon has grown across editions on the
+                    <a href="{% url 'portal_stats_comparison' %}">year-over-year comparison page</a>.
+                </p>
             </div>
-        </div>
-        <div class="row g-4 mt-2">
-            {% for comparison in stats.historical_comparison %}
-                <div class="col-md-6">
-                    <div class="card h-100">
-                        <div class="card-body">
-                            <div id="{{ comparison.chart_id }}" class="chart-container">
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            {% endfor %}
         </div>
     </div>
 {% endblock content %}

--- a/templates/portal/stats.html
+++ b/templates/portal/stats.html
@@ -28,16 +28,26 @@
         <h2 class="pb-2 border-bottom">
             PyLadiesCon Stats and Numbers — {{ selected_conference.year }}
         </h2>
-        {% if conferences %}
-            <div class="btn-group mb-3" role="group" aria-label="Conference year">
-                {% for conference in conferences %}
-                    <a href="?year={{ conference.year }}"
-                       class="btn btn-sm {% if conference == selected_conference %}btn-primary{% else %}btn-outline-primary{% endif %}">
-                        {{ conference.year }}
-                    </a>
-                {% endfor %}
+        <div class="row align-items-center mb-3">
+            <div class="col-md-8">
+                {% if conferences %}
+                    <div class="btn-group" role="group" aria-label="Conference year">
+                        {% for conference in conferences %}
+                            <a href="?year={{ conference.year }}"
+                               class="btn btn-sm {% if conference == selected_conference %}btn-primary{% else %}btn-outline-primary{% endif %}">
+                                {{ conference.year }}
+                            </a>
+                        {% endfor %}
+                    </div>
+                {% endif %}
             </div>
-        {% endif %}
+            <div class="col-md-4 text-md-end mt-2 mt-md-0">
+                <a href="{% url 'portal_stats_comparison' %}"
+                   class="btn btn-sm btn-outline-secondary">
+                    <i class="bi bi-graph-up"></i> Year-over-Year Comparison
+                </a>
+            </div>
+        </div>
         {% if historical_snapshot %}
             <div class="alert alert-info" role="alert">
                 <h4 class="alert-heading">
@@ -170,16 +180,5 @@
             {% include "volunteer/volunteer_stats.html" %}
             {% include "attendee/attendee_stats.html" %}
         {% endif %}
-        <div class="row mt-5">
-            <div class="col-12">
-                <h3 class="pb-2 border-bottom">
-                    <i class="bi bi-graph-up"></i> Year-over-Year Comparison
-                </h3>
-                <p>
-                    See how PyLadiesCon has grown across editions on the
-                    <a href="{% url 'portal_stats_comparison' %}">year-over-year comparison page</a>.
-                </p>
-            </div>
-        </div>
     </div>
 {% endblock content %}

--- a/templates/portal/stats_comparison.html
+++ b/templates/portal/stats_comparison.html
@@ -1,0 +1,41 @@
+{% extends "portal/base.html" %}
+{% load i18n %}
+{% block extra_head %}
+    {{ block.super }}
+    <!--Google Charts-->
+    <script type="text/javascript" src="https://www.gstatic.com/charts/loader.js"></script>
+    <script type="text/javascript">
+    google.charts.load('current', { 'packages': ['corechart', 'bar'] });
+    google.charts.setOnLoadCallback(drawChart);
+    function drawChart() {
+        {% include "portal/historical_comparison_charts.html" %}
+    }
+    </script>
+    <style>
+        .chart-container {
+            height: 300px;
+        }
+    </style>
+{% endblock extra_head %}
+{% block content %}
+    <div class="container px-4 py-3">
+        <h2 class="pb-2 border-bottom">
+            <i class="bi bi-graph-up"></i> Year-over-Year Comparison
+        </h2>
+        <p>
+            <a href="{% url 'portal_stats' %}">&larr; Back to current stats</a>
+        </p>
+        <div class="row g-4 mt-2">
+            {% for comparison in historical_comparison %}
+                <div class="col-md-6">
+                    <div class="card h-100">
+                        <div class="card-body">
+                            <div id="{{ comparison.chart_id }}" class="chart-container">
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+    </div>
+{% endblock content %}

--- a/templates/portal/stats_comparison.html
+++ b/templates/portal/stats_comparison.html
@@ -23,7 +23,7 @@
             <i class="bi bi-graph-up"></i> Year-over-Year Comparison
         </h2>
         <p>
-            <a href="{% url 'portal_stats' %}">&larr; Back to current stats</a>
+            <a href="{% url 'portal_stats' %}"><i class="bi bi-arrow-left"></i> Back to current stats</a>
         </p>
         <div class="row g-4 mt-2">
             {% for comparison in historical_comparison %}

--- a/tests/portal/test_common.py
+++ b/tests/portal/test_common.py
@@ -4,6 +4,7 @@ from django.core.cache import cache
 
 from attendee.models import AttendeeProfile, PretixOrder, PretixOrderstatus
 from portal.common import (
+    get_historical_comparison_data,
     get_sponsorship_committed_amount_stats_cache,
     get_sponsorship_committed_count_stats_cache,
     get_sponsorship_paid_amount_stats_cache,
@@ -16,6 +17,7 @@ from portal.common import (
     get_volunteer_signup_stat_cache,
 )
 from portal.constants import (
+    CACHE_KEY_HISTORICAL_COMPARISON,
     CACHE_KEY_SPONSORSHIP_COMMITTED,
     CACHE_KEY_SPONSORSHIP_COMMITTED_COUNT,
     CACHE_KEY_SPONSORSHIP_PAID,
@@ -26,6 +28,7 @@ from portal.constants import (
     CACHE_KEY_TOTAL_SPONSORSHIPS,
     CACHE_KEY_VOLUNTEER_SIGNUPS_COUNT,
 )
+from portal.models import Conference
 from sponsorship.models import (
     SponsorshipProfile,
     SponsorshipProgressStatus,
@@ -404,3 +407,45 @@ class TestAttendeeStats:
         breakdown = get_attendee_breakdown(conference)
         for b in breakdown:
             assert b["data"] == []
+
+
+@pytest.mark.django_db
+class TestHistoricalComparison:
+    def test_combines_snapshot_and_live_editions(self, conference):
+        """Pre-portal editions use their snapshot; live editions are aggregated."""
+        cache.delete(CACHE_KEY_HISTORICAL_COMPARISON)
+        Conference.objects.create(
+            year=2024,
+            name="PyLadiesCon 2024",
+            slug="2024",
+            proposals_count=192,
+            historical_snapshot={
+                "registrations": 732,
+                "sponsors": 11,
+                "sponsorship_amount": 10000,
+                "donors": 105,
+                "donation_amount": 1520,
+            },
+        )
+
+        data = get_historical_comparison_data()
+        assert len(data) == 7  # one chart per metric
+
+        registrations = next(
+            c for c in data if c["chart_id"] == "registrations_comparison"
+        )
+        years = [row[0] for row in registrations["data"]]
+        assert "2024" in years and "2025" in years  # both editions present
+        # 2024 comes from the snapshot; 2025 (active, no data) is live → 0.
+        assert dict(registrations["data"])["2024"] == 732
+        assert dict(registrations["data"])["2025"] == 0
+
+        # proceeds = sponsorship + donation, from the snapshot for 2024.
+        proceeds = next(c for c in data if c["chart_id"] == "proceeds_comparison")
+        assert dict(proceeds["data"])["2024"] == 10000 + 1520
+
+    def test_result_is_cached(self, conference):
+        cache.delete(CACHE_KEY_HISTORICAL_COMPARISON)
+        first = get_historical_comparison_data()
+        assert cache.get(CACHE_KEY_HISTORICAL_COMPARISON) == first
+        assert get_historical_comparison_data() == first

--- a/tests/portal/test_views.py
+++ b/tests/portal/test_views.py
@@ -85,6 +85,11 @@ class TestPortalStats:
         assert "600" in content  # snapshot registrations
         assert "164" in content  # proposals_count
 
+    def test_stats_comparison_page_is_public(self, client, conference):
+        response = client.get(reverse("portal_stats_comparison"))
+        assert response.status_code == 200
+        assert "Year-over-Year Comparison" in response.content.decode()
+
 
 @pytest.mark.django_db
 class TestPyladiesChapters:


### PR DESCRIPTION
**Phase 8** — gives the cross-year comparison its own page and rebuilds it from real per-year data (made possible by 7a's conference-aware aggregations).

## What changed
- **`/stats/comparison/`** — new `stats_comparison` view + `portal/stats_comparison.html`. The comparison charts move off the bottom of `/stats/`, which now just links to the new page.
- **`get_historical_comparison_data()`** rebuilt: iterates **every `Conference`** (ordered by year); each edition contributes one bar per chart, taken from its **live stats** or, for editions that predate the portal, its **`historical_snapshot`** (new `_conference_comparison_metrics` helper). It's no longer part of `get_stats_cached_values` (the per-conference dict shouldn't carry cross-year data).
- **Deleted the now-unused constants** `HISTORICAL_STATS`, `PROPOSALS_2025_COUNT`, `SPONSORSHIP_GOAL_AMOUNT`, `DONATION_GOAL_AMOUNT`. The Phase-3 backfill migration keeps its own inlined copies, so it stays replayable on a fresh DB.

## Why this is "real data"
Before, 2023/2024 were hardcoded and the live year was a one-off. Now the comparison is driven entirely by `Conference` rows: snapshots for pre-portal years (backfilled in Phase 3), live aggregations for everything since. New editions appear automatically.

## Tests
- Comparison combines snapshot (2024) + live (2025) editions; proceeds = sponsorship + donation; result is cached; the page is public.
- **419 pass, 100% coverage**; black/isort/flake8/djlint clean; no schema change.

Refs #321