### PR TITLE
Clone teams from a previous edition (Multi-year #9, clone-teams)

### DIFF
--- a/portal/admin.py
+++ b/portal/admin.py
@@ -1,6 +1,26 @@
-from django.contrib import admin
+from django.contrib import admin, messages
 
 from .models import Conference
+
+
+@admin.action(description="Clone teams from the previous edition")
+def clone_teams_from_previous(modeladmin, request, queryset):
+    """Populate each selected edition's teams from the prior year's edition."""
+    for target in queryset:
+        source = Conference.objects.filter(year=target.year - 1).first()
+        if source is None:
+            modeladmin.message_user(
+                request,
+                f"No previous edition found for {target}.",
+                level=messages.WARNING,
+            )
+            continue
+        created = target.clone_teams_from(source)
+        modeladmin.message_user(
+            request,
+            f"Cloned {created} team(s) from {source} into {target}.",
+            level=messages.SUCCESS,
+        )
 
 
 @admin.register(Conference)
@@ -11,3 +31,4 @@ class ConferenceAdmin(admin.ModelAdmin):
     search_fields = ("name", "year", "slug")
     ordering = ("-year",)
     prepopulated_fields = {"slug": ("name",)}
+    actions = [clone_teams_from_previous]

--- a/portal/models.py
+++ b/portal/models.py
@@ -94,3 +94,27 @@ class Conference(BaseModel):
     def get_active(cls):
         """Return the active conference, or ``None`` if none is set."""
         return cls.objects.filter(is_active=True).first()
+
+    def clone_teams_from(self, source):
+        """Copy the team structure from another edition into this one.
+
+        Copies each team's name, description, and open-to-new-members flag but
+        not its team leads (those are per-edition volunteers). Teams whose name
+        already exists in this edition are skipped, so it is safe to run more
+        than once. Returns the number of teams created.
+        """
+        from volunteer.models import Team
+
+        existing = set(self.teams.values_list("short_name", flat=True))
+        created = 0
+        for team in source.teams.all():
+            if team.short_name in existing:
+                continue
+            Team.objects.create(
+                conference=self,
+                short_name=team.short_name,
+                description=team.description,
+                open_to_new_members=team.open_to_new_members,
+            )
+            created += 1
+        return created

--- a/tests/portal/test_admin.py
+++ b/tests/portal/test_admin.py
@@ -1,0 +1,50 @@
+import pytest
+from django.urls import reverse
+
+from portal.models import Conference
+
+
+@pytest.fixture(autouse=True)
+def conference():
+    """This module creates its own Conference rows, so skip the shared one."""
+    return None
+
+
+@pytest.mark.django_db
+class TestCloneTeamsAction:
+    def _run_action(self, client, pks):
+        return client.post(
+            reverse("admin:portal_conference_changelist"),
+            {"action": "clone_teams_from_previous", "_selected_action": pks},
+            follow=True,
+        )
+
+    def test_clones_teams_from_previous_edition(self, client, admin_user):
+        from volunteer.models import Team
+
+        source = Conference.objects.create(
+            year=2025, name="PyLadiesCon 2025", slug="2025"
+        )
+        target = Conference.objects.create(
+            year=2026, name="PyLadiesCon 2026", slug="2026"
+        )
+        Team.objects.create(conference=source, short_name="Comms", description="c")
+        client.force_login(admin_user)
+
+        response = self._run_action(client, [target.pk])
+
+        assert response.status_code == 200
+        assert target.teams.count() == 1
+        assert "Cloned 1 team(s)" in response.content.decode()
+
+    def test_warns_when_no_previous_edition(self, client, admin_user):
+        target = Conference.objects.create(
+            year=2026, name="PyLadiesCon 2026", slug="2026"
+        )
+        client.force_login(admin_user)
+
+        response = self._run_action(client, [target.pk])
+
+        assert response.status_code == 200
+        assert target.teams.count() == 0
+        assert "No previous edition" in response.content.decode()

--- a/tests/portal/test_models.py
+++ b/tests/portal/test_models.py
@@ -113,3 +113,61 @@ class TestActiveConferenceContextProcessor:
 
     def test_returns_none_when_no_active(self):
         assert active_conference(None) == {"active_conference": None}
+
+
+@pytest.mark.django_db
+class TestCloneTeamsFrom:
+    def test_copies_team_structure_but_not_leads(self):
+        from django.contrib.auth import get_user_model
+
+        from volunteer.models import Team, VolunteerProfile
+
+        source = Conference.objects.create(
+            year=2025, name="PyLadiesCon 2025", slug="2025"
+        )
+        target = Conference.objects.create(
+            year=2026, name="PyLadiesCon 2026", slug="2026"
+        )
+        lead = VolunteerProfile.objects.create(
+            user=get_user_model().objects.create(username="lead"), conference=source
+        )
+        team = Team.objects.create(
+            conference=source,
+            short_name="Comms",
+            description="Communications team",
+            open_to_new_members=False,
+        )
+        team.team_leads.add(lead)
+
+        created = target.clone_teams_from(source)
+
+        assert created == 1
+        cloned = target.teams.get()
+        assert cloned.short_name == "Comms"
+        assert cloned.description == "Communications team"
+        assert cloned.open_to_new_members is False
+        assert cloned.team_leads.count() == 0  # leads are per-edition
+
+    def test_skips_teams_already_present(self):
+        from volunteer.models import Team
+
+        source = Conference.objects.create(
+            year=2025, name="PyLadiesCon 2025", slug="2025"
+        )
+        target = Conference.objects.create(
+            year=2026, name="PyLadiesCon 2026", slug="2026"
+        )
+        Team.objects.create(conference=source, short_name="Comms", description="a")
+        Team.objects.create(conference=source, short_name="Design", description="b")
+        Team.objects.create(
+            conference=target, short_name="Comms", description="kept as-is"
+        )
+
+        created = target.clone_teams_from(source)
+
+        assert created == 1  # only Design is new; Comms already exists
+        assert set(target.teams.values_list("short_name", flat=True)) == {
+            "Comms",
+            "Design",
+        }
+        assert target.teams.get(short_name="Comms").description == "kept as-is"


### PR DESCRIPTION
**Phase 9 — first admin action.** Starting a new conference edition shouldn't mean recreating every team by hand.

## What changed
- **`Conference.clone_teams_from(source)`** — copies each team's **name, description, and open-to-new-members** flag into this edition. It:
  - **skips** teams whose name already exists in this edition (safe to re-run), and
  - does **not** carry over **team leads** (those are per-edition volunteers — leads get assigned fresh).
  - returns the number of teams created. This method is the reusable building block the **#341 "start a new year" wizard** will call.
- **ConferenceAdmin action "Clone teams from the previous edition"** — for each selected edition, clones from the **year-1** edition, warning when there isn't one.

## Usage
In `/admin/portal/conference/`, select the new edition → Actions → *Clone teams from the previous edition*.

## Tests
- Method: copies structure, skips already-present teams, doesn't copy leads, returns count.
- Admin action: clones from the prior edition; warns when none exists.
- **423 pass, 100% coverage**; black/isort/flake8/djlint(+lint) clean; no schema change.

## Phase 9 follow-ups (separate PRs)
Bring-forward returning volunteers (#333), freeze stats, navbar year indicator.

Refs #321