### PR TITLE
Bring returning volunteers forward to a new edition (#333)

### DIFF
--- a/tests/volunteer/test_admin.py
+++ b/tests/volunteer/test_admin.py
@@ -51,6 +51,68 @@ class TestAdminActions:
         profile.refresh_from_db()
         assert profile.application_status == ApplicationStatus.WAITLISTED
 
+    def _bring_forward(self, client, profile, query=""):
+        data = {
+            "action": "bring_forward_to_active_conference",
+            "select_across": ["0"],
+            "index": ["0"],
+            "_selected_action": [str(profile.id)],
+        }
+        url = reverse("admin:volunteer_volunteerprofile_changelist") + query
+        return client.post(url, data, follow=True)
+
+    def test_bring_forward_action(self, client, admin_user, conference):
+        # conference (2025) is active by default; make 2026 the active edition.
+        new_edition = Conference.objects.create(
+            year=2026, name="PyLadiesCon 2026", slug="2026", is_active=True
+        )
+        returner = User.objects.create_user("returner", email="r@example.com")
+        profile = VolunteerProfile.objects.create(
+            user=returner, conference=conference, discord_username="d"
+        )
+        client.force_login(admin_user)
+        mail.outbox.clear()
+
+        # ?conference=all so the past-edition profile is in the changelist.
+        response = self._bring_forward(client, profile, "?conference=all")
+
+        assert response.status_code == 200
+        assert "Brought 1 volunteer(s) forward" in response.content.decode()
+        new_profile = VolunteerProfile.objects.get(
+            user=returner, conference=new_edition
+        )
+        assert new_profile.application_status == ApplicationStatus.PENDING
+        assert len(mail.outbox) == 0
+
+    def test_bring_forward_skips_existing(self, client, admin_user, conference):
+        # Active edition is 2025; the profile already lives there → skipped.
+        returner = User.objects.create_user("returner", email="r@example.com")
+        profile = VolunteerProfile.objects.create(
+            user=returner, conference=conference, discord_username="d"
+        )
+        client.force_login(admin_user)
+
+        response = self._bring_forward(client, profile)
+
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert "Brought 0 volunteer(s) forward" in content
+        assert "1 already had a profile" in content
+
+    def test_bring_forward_no_active_conference(self, client, admin_user, conference):
+        conference.is_active = False
+        conference.save()
+        returner = User.objects.create_user("returner", email="r@example.com")
+        profile = VolunteerProfile.objects.create(
+            user=returner, conference=conference, discord_username="d"
+        )
+        client.force_login(admin_user)
+
+        response = self._bring_forward(client, profile, "?conference=all")
+
+        assert response.status_code == 200
+        assert "No active conference is set" in response.content.decode()
+
 
 @pytest.mark.django_db
 class TestPyLadiesChapterAdmin:

--- a/tests/volunteer/test_models.py
+++ b/tests/volunteer/test_models.py
@@ -734,3 +734,62 @@ class TestConferenceLink:
             short_name="Test Team", description="Test", conference=conference
         )
         assert list(conference.teams.all()) == [team]
+
+
+@pytest.mark.django_db
+class TestBringForwardTo:
+    def test_copies_details_as_pending_without_email(
+        self, portal_user, language, conference
+    ):
+        from portal.models import Conference
+
+        source = VolunteerProfile(
+            user=portal_user,
+            conference=conference,
+            region=Region.NORTH_AMERICA,
+            discord_username="mydiscord",
+            github_username="octocat",
+            availability_hours_per_week=5,
+        )
+        source.save()
+        source.language.add(language)
+        team = Team.objects.create(
+            conference=conference, short_name="Comms", description="c"
+        )
+        source.teams.add(team)
+        target = Conference.objects.create(
+            year=2026, name="PyLadiesCon 2026", slug="2026"
+        )
+        mail.outbox.clear()
+
+        new_profile = source.bring_forward_to(target)
+
+        assert new_profile is not None
+        assert new_profile.conference == target
+        assert new_profile.user == portal_user
+        assert new_profile.application_status == ApplicationStatus.PENDING
+        assert new_profile.github_username == "octocat"
+        assert new_profile.discord_username == "mydiscord"
+        assert new_profile.region == Region.NORTH_AMERICA
+        assert new_profile.availability_hours_per_week == 5
+        assert list(new_profile.language.all()) == [language]
+        assert new_profile.teams.count() == 0  # team assignments not carried
+        assert new_profile.roles.count() == 0
+        assert len(mail.outbox) == 0  # no unsolicited "application received" email
+
+    def test_returns_none_when_already_in_target(self, portal_user, conference):
+        from portal.models import Conference
+
+        target = Conference.objects.create(
+            year=2026, name="PyLadiesCon 2026", slug="2026"
+        )
+        source = VolunteerProfile.objects.create(
+            user=portal_user, conference=conference
+        )
+        VolunteerProfile.objects.create(user=portal_user, conference=target)
+
+        assert source.bring_forward_to(target) is None
+        assert (
+            VolunteerProfile.objects.filter(user=portal_user, conference=target).count()
+            == 1
+        )

--- a/volunteer/admin.py
+++ b/volunteer/admin.py
@@ -1,4 +1,4 @@
-from django.contrib import admin
+from django.contrib import admin, messages
 from import_export import resources
 from import_export.admin import ImportExportModelAdmin
 from import_export.fields import Field
@@ -20,6 +20,34 @@ def bulk_waitlist_volunteers(modeladmin, request, queryset):
     for volunteer in queryset:
         volunteer.application_status = ApplicationStatus.WAITLISTED
         volunteer.save()
+
+
+@admin.action(description="Bring selected volunteers forward to the active conference")
+def bring_forward_to_active_conference(modeladmin, request, queryset):
+    """Carry returning volunteers into the active edition without re-applying.
+
+    Copies each selected profile's details into a new PENDING profile for the
+    active conference; volunteers who already have a profile there are skipped.
+    """
+    active = Conference.get_active()
+    if active is None:
+        modeladmin.message_user(
+            request, "No active conference is set.", level=messages.ERROR
+        )
+        return
+    created = 0
+    skipped = 0
+    for volunteer in queryset:
+        if volunteer.bring_forward_to(active) is None:
+            skipped += 1
+        else:
+            created += 1
+    modeladmin.message_user(
+        request,
+        f"Brought {created} volunteer(s) forward into {active}; "
+        f"{skipped} already had a profile there.",
+        level=messages.SUCCESS,
+    )
 
 
 class VolunteerProfileResource(resources.ModelResource):
@@ -80,7 +108,7 @@ class VolunteerProfileAdmin(ImportExportModelAdmin):
         "application_status",
     )
     list_filter = (ActiveConferenceFilter, "region", "application_status")
-    actions = [bulk_waitlist_volunteers]
+    actions = [bulk_waitlist_volunteers, bring_forward_to_active_conference]
     resource_classes = [VolunteerProfileResource]
     # Dual-list ("available"/"chosen") pickers for the many-to-many fields.
     filter_horizontal = ("teams", "roles", "language")

--- a/volunteer/models.py
+++ b/volunteer/models.py
@@ -183,6 +183,42 @@ class VolunteerProfile(BaseModel):
         """Returns False if the volunteer profile is pending."""
         return self.application_status == ApplicationStatus.PENDING
 
+    def bring_forward_to(self, target_conference):
+        """Carry a returning volunteer into another edition without re-applying.
+
+        Copies this profile's details (not its team/role assignments) into a new
+        PENDING profile for ``target_conference``, so a returning volunteer does
+        not have to fill in the form again; the organizer still reviews it.
+        Returns the new profile, or ``None`` if the user already has a profile
+        in that edition. No "application received" emails are sent.
+        """
+        if VolunteerProfile.objects.filter(
+            user=self.user, conference=target_conference
+        ).exists():
+            return None
+
+        new_profile = VolunteerProfile(
+            user=self.user,
+            conference=target_conference,
+            application_status=ApplicationStatus.PENDING,
+            github_username=self.github_username,
+            discord_username=self.discord_username,
+            instagram_username=self.instagram_username,
+            bluesky_username=self.bluesky_username,
+            mastodon_url=self.mastodon_url,
+            x_username=self.x_username,
+            linkedin_url=self.linkedin_url,
+            languages_spoken=self.languages_spoken,
+            additional_comments=self.additional_comments,
+            availability_hours_per_week=self.availability_hours_per_week,
+            region=self.region,
+            chapter=self.chapter,
+        )
+        new_profile.skip_notifications = True
+        new_profile.save()
+        new_profile.language.set(self.language.all())
+        return new_profile
+
     def clean(self):
         super().clean()
         self._validate_github_username()
@@ -459,6 +495,12 @@ def volunteer_profile_signal(sender, instance, created, **kwargs):
     Queue a background task to notify the user (and the internal team on
     creation) about their volunteer application status.
     """
+    # Bulk operations (e.g. bringing returning volunteers forward into a new
+    # edition) set this so the volunteer is not emailed an unsolicited
+    # "application received" notice.
+    if getattr(instance, "skip_notifications", False):
+        return
+
     # Local import avoids a circular import (tasks imports this module).
     from common.tasks import enqueue
 


### PR DESCRIPTION
**Phase 9 — closes #333.** Returning volunteers shouldn't have to re-fill the whole form for each edition. Organizers can now carry them into the new edition; new folks still sign up fresh.

## What changed
- **`VolunteerProfile.bring_forward_to(target_conference)`** — copies the profile's details (github/discord/socials/region/chapter/languages/availability) into a **new PENDING profile** for the target edition. Per the agreed behavior:
  - **status = PENDING** — the organizer still reviews it (nothing auto-activates).
  - **team/role assignments are NOT carried** — assigned fresh during this year's review.
  - returns `None` if the user **already has a profile** in the target edition.
  - **no "application received" email** is sent.
- **Signal guard** — `volunteer_profile_signal` honors a `skip_notifications` flag so bulk bring-forward doesn't spam volunteers with unsolicited application notices.
- **Admin action** "Bring selected volunteers forward to the active conference" on the Volunteer admin (existing-in-target are skipped, reported in the message).

## Usage
In `/admin/.../volunteerprofile/`, switch the conference filter to last year, select the returning volunteers → Actions → *Bring selected volunteers forward to the active conference*. They appear as PENDING in the new edition's review queue with their details pre-filled.

## Tests
- Method: copies details as PENDING, no teams/roles, no email; returns None when already present.
- Action: brings forward from a past edition; skips existing; errors when no active conference.
- **428 pass, 100% coverage**; black/isort/flake8 clean; no schema change.

Closes #333
Refs #321