### PR TITLE
Freeze a closed edition's stats (Multi-year #9, freeze-stats)

### DIFF
--- a/portal/admin.py
+++ b/portal/admin.py
@@ -23,6 +23,18 @@ def clone_teams_from_previous(modeladmin, request, queryset):
         )
 
 
+@admin.action(description="Freeze stats (snapshot the final numbers)")
+def freeze_conference_stats(modeladmin, request, queryset):
+    """Persist each selected edition's live metrics as its final snapshot."""
+    for conference in queryset:
+        conference.freeze_stats()
+        modeladmin.message_user(
+            request,
+            f"Froze stats for {conference}.",
+            level=messages.SUCCESS,
+        )
+
+
 @admin.register(Conference)
 class ConferenceAdmin(admin.ModelAdmin):
     list_display = ("name", "year", "slug", "is_active")
@@ -31,4 +43,4 @@ class ConferenceAdmin(admin.ModelAdmin):
     search_fields = ("name", "year", "slug")
     ordering = ("-year",)
     prepopulated_fields = {"slug": ("name",)}
-    actions = [clone_teams_from_previous]
+    actions = [clone_teams_from_previous, freeze_conference_stats]

--- a/portal/models.py
+++ b/portal/models.py
@@ -118,3 +118,31 @@ class Conference(BaseModel):
             )
             created += 1
         return created
+
+    def freeze_stats(self):
+        """Snapshot this edition's live metrics into ``historical_snapshot``.
+
+        Once frozen, the comparison and historical-fallback views read these
+        fixed numbers instead of recomputing them, so a closed edition's stats
+        stay final. Amounts are stored as floats so the dict is JSON-safe.
+        Returns the snapshot dict.
+        """
+        from portal.common import (
+            get_attendee_count_cache,
+            get_donors_count_cache,
+            get_sponsorship_committed_amount_stats_cache,
+            get_sponsorship_committed_count_stats_cache,
+            get_total_donations_amount_cache,
+        )
+
+        self.historical_snapshot = {
+            "registrations": get_attendee_count_cache(self),
+            "sponsors": get_sponsorship_committed_count_stats_cache(self),
+            "sponsorship_amount": float(
+                get_sponsorship_committed_amount_stats_cache(self)
+            ),
+            "donors": get_donors_count_cache(self),
+            "donation_amount": float(get_total_donations_amount_cache(self)),
+        }
+        self.save()
+        return self.historical_snapshot

--- a/templates/portal/stats.html
+++ b/templates/portal/stats.html
@@ -51,10 +51,10 @@
         {% if historical_snapshot %}
             <div class="alert alert-info" role="alert">
                 <h4 class="alert-heading">
-                    Limited data
+                    Final numbers
                 </h4>
                 <p class="mb-0">
-                    {{ selected_conference }} predates this portal — showing the recorded summary numbers.
+                    Showing the final recorded numbers for {{ selected_conference }}.
                 </p>
             </div>
             <div class="row g-3 mb-4 row-cols-2 row-cols-md-3">

--- a/tests/portal/test_admin.py
+++ b/tests/portal/test_admin.py
@@ -48,3 +48,29 @@ class TestCloneTeamsAction:
         assert response.status_code == 200
         assert target.teams.count() == 0
         assert "No previous edition" in response.content.decode()
+
+
+@pytest.mark.django_db
+class TestFreezeStatsAction:
+    def test_freezes_selected_edition(self, client, admin_user):
+        conf = Conference.objects.create(
+            year=2025, name="PyLadiesCon 2025", slug="2025"
+        )
+        client.force_login(admin_user)
+
+        response = client.post(
+            reverse("admin:portal_conference_changelist"),
+            {"action": "freeze_conference_stats", "_selected_action": [conf.pk]},
+            follow=True,
+        )
+
+        assert response.status_code == 200
+        assert "Froze stats" in response.content.decode()
+        conf.refresh_from_db()
+        assert set(conf.historical_snapshot) == {
+            "registrations",
+            "sponsors",
+            "sponsorship_amount",
+            "donors",
+            "donation_amount",
+        }

--- a/tests/portal/test_models.py
+++ b/tests/portal/test_models.py
@@ -171,3 +171,34 @@ class TestCloneTeamsFrom:
             "Design",
         }
         assert target.teams.get(short_name="Comms").description == "kept as-is"
+
+
+@pytest.mark.django_db
+class TestFreezeStats:
+    def test_snapshots_live_metrics_as_json_safe(self):
+        from django.core.cache import cache
+
+        from sponsorship.models import SponsorshipProfile, SponsorshipProgressStatus
+
+        cache.clear()
+        conf = Conference.objects.create(
+            year=2025, name="PyLadiesCon 2025", slug="2025"
+        )
+        SponsorshipProfile.objects.create(
+            organization_name="Acme",
+            conference=conf,
+            progress_status=SponsorshipProgressStatus.PAID,
+            sponsorship_override_amount=5000,
+        )
+
+        snapshot = conf.freeze_stats()
+
+        assert snapshot["sponsors"] == 1
+        assert snapshot["sponsorship_amount"] == 5000.0
+        assert isinstance(snapshot["sponsorship_amount"], float)  # JSON-safe
+        assert isinstance(snapshot["donation_amount"], float)
+        assert snapshot["registrations"] == 0
+        assert snapshot["donors"] == 0
+
+        conf.refresh_from_db()
+        assert conf.historical_snapshot == snapshot

--- a/tests/portal/test_views.py
+++ b/tests/portal/test_views.py
@@ -81,7 +81,7 @@ class TestPortalStats:
         response = client.get(reverse("portal_stats") + "?year=2024")
         assert response.status_code == 200
         content = response.content.decode()
-        assert "Limited data" in content
+        assert "Final numbers" in content
         assert "600" in content  # snapshot registrations
         assert "164" in content  # proposals_count
 


### PR DESCRIPTION
**Phase 9 — freeze stats.** When an edition wraps up, organizers can snapshot its live numbers so they become final and stop recomputing.

## What changed
- **`Conference.freeze_stats()`** — writes the edition's live **registrations, sponsors, sponsorship amount, donors, donation amount** into `historical_snapshot` (amounts stored as `float` so the JSONField stays serializable). Returns the snapshot. Reusable by the #341 wizard.
- **ConferenceAdmin action** "Freeze stats (snapshot the final numbers)".
- Since the comparison page and the `/stats/` fallback already read `historical_snapshot`, a frozen edition now shows these **fixed final numbers** everywhere — without recomputing from live data.
- **Generalized the `/stats/` snapshot banner** ("Final numbers" / "showing the final recorded numbers for …") because that fallback now covers frozen in-portal editions too, not just pre-portal years.

## How it fits
`historical_snapshot` was the mechanism for pre-portal years (2023/24, backfilled in Phase 3) and the comparison page (Phase 8). Freeze reuses it: a closed 2025 edition becomes a fixed snapshot just like 2023/24, so its numbers won't drift if records change later.

## Tests
- Method: snapshots live metrics, amounts are JSON-safe floats, persisted on the model.
- Action: freezes the selected edition (snapshot keys populated).
- **430 pass, 100% coverage**; black/isort/flake8/djlint(+lint) clean; no schema change.

## Phase 9 remaining
Navbar year indicator (last one).

Refs #321