### PR TITLE
Show the active edition's year in the navbar (Multi-year #9, navbar)

### DIFF
--- a/templates/portal/base.html
+++ b/templates/portal/base.html
@@ -45,6 +45,9 @@
              aria-label="Fourth navbar example">
             <div class="container-fluid">
                 <a class="navbar-brand" href="{% url "index" %}">PyLadiesCon Portal</a>
+                {% if active_conference %}
+                    <span class="badge bg-secondary me-2" title="Active conference edition">{{ active_conference.year }}</span>
+                {% endif %}
                 <button class="navbar-toggler"
                         type="button"
                         data-bs-toggle="collapse"

--- a/tests/portal/test_views.py
+++ b/tests/portal/test_views.py
@@ -17,6 +17,13 @@ class TestPortalIndex:
         assert "Sign up" in response.content.decode()
         assert "Login" in response.content.decode()
 
+    def test_navbar_shows_active_conference_year(self, client, conference):
+        response = client.get(reverse("index"))
+        assert response.status_code == 200
+        content = response.content.decode()
+        assert "Active conference edition" in content  # the navbar badge
+        assert str(conference.year) in content
+
     def test_index_authenticated_no_profile_created(self, client, portal_user):
 
         client.force_login(portal_user)


### PR DESCRIPTION
**Phase 9 — final action.** A small badge next to the navbar brand surfaces the **active conference year** on every page, so it's always clear which edition the portal is operating on.

## What changed
- **`templates/portal/base.html`** — a `{{ active_conference.year }}` badge beside the "PyLadiesCon Portal" brand, using the existing `active_conference` context processor. Hidden when no edition is active.

## Tests
- The index page renders the badge with the active year.
- **431 pass, 100% coverage**; black/isort/flake8/djlint(+lint) clean; no schema change.

## Phase 9 complete
Clone teams (#352), bring-forward volunteers (#353, closed #333), freeze stats (#354), and this navbar indicator — all merged/open.

Refs #321