### PR TITLE
Add a "Your Conferences" history view (Multi-year #10)

### DIFF
--- a/templates/volunteer/index.html
+++ b/templates/volunteer/index.html
@@ -73,6 +73,12 @@
             Links and Resources
         </h2>
         <ul class="list-unstyled ps-8">
+            <li>
+                <a href="{% url 'volunteer:my_conferences' %}" class="icon-link">
+                    Your Conferences
+                    <i class="fa-solid fa-chevron-right"></i>
+                </a> See all the editions you have volunteered for.
+            </li>
             {% if profile.id %}
                 <li>
                     <a href="{% url 'volunteer:index' %}" class="icon-link">

--- a/templates/volunteer/my_conferences.html
+++ b/templates/volunteer/my_conferences.html
@@ -1,0 +1,70 @@
+{% extends "portal/base.html" %}
+{% load i18n %}
+{% block content %}
+    <div class="container px-4 py-3">
+        <h1 class="display-5">
+            {% trans "Your Conferences" %}
+        </h1>
+        <p class="text-muted">
+            {% trans "Editions you have volunteered for." %}
+        </p>
+        {% if profiles %}
+            <table class="table table-hover align-middle">
+                <thead class="table-light">
+                    <tr>
+                        <th>
+                            {% trans "Edition" %}
+                        </th>
+                        <th>
+                            {% trans "Status" %}
+                        </th>
+                        <th>
+                            {% trans "Teams" %}
+                        </th>
+                        <th>
+                            {% trans "Roles" %}
+                        </th>
+                        <th>
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for profile in profiles %}
+                        <tr>
+                            <td>
+                                {{ profile.conference.year }}
+                            </td>
+                            <td>
+                                {{ profile.application_status }}
+                            </td>
+                            <td>
+                                {% for team in profile.teams.all %}
+                                    {{ team.short_name }}
+                                    {% if not forloop.last %}
+                                        ,
+                                    {% endif %}
+                                {% endfor %}
+                            </td>
+                            <td>
+                                {% for role in profile.roles.all %}
+                                    {{ role.short_name }}
+                                    {% if not forloop.last %}
+                                        ,
+                                    {% endif %}
+                                {% endfor %}
+                            </td>
+                            <td>
+                                <a href="{% url 'volunteer:volunteer_profile_detail' profile.id %}"
+                                   class="btn btn-sm btn-outline-primary">{% trans "View" %}</a>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        {% else %}
+            <p class="fs-5">
+                {% trans "You have not volunteered for any edition yet." %}
+            </p>
+        {% endif %}
+    </div>
+{% endblock content %}

--- a/tests/volunteer/test_views.py
+++ b/tests/volunteer/test_views.py
@@ -1147,3 +1147,47 @@ class TestVolunteerListYearSwitcher:
         )
         assert past_profile in switched_list
         assert active_profile not in switched_list
+
+
+@pytest.mark.django_db
+class TestMyConferences:
+    def test_lists_users_editions_newest_first(self, client, portal_user, conference):
+        past = Conference.objects.create(
+            year=2024, name="PyLadiesCon 2024", slug="2024"
+        )
+        VolunteerProfile.objects.create(
+            user=portal_user, conference=conference, discord_username="d"
+        )
+        VolunteerProfile.objects.create(
+            user=portal_user, conference=past, discord_username="d"
+        )
+        client.force_login(portal_user)
+
+        response = client.get(reverse("volunteer:my_conferences"))
+
+        assert response.status_code == 200
+        profiles = list(response.context["profiles"])
+        assert [p.conference.year for p in profiles] == [2025, 2024]
+        assert "Your Conferences" in response.content.decode()
+
+    def test_only_shows_own_profiles(self, client, portal_user, conference):
+        from django.contrib.auth.models import User
+
+        other = User.objects.create_user("other", email="o@example.com")
+        VolunteerProfile.objects.create(
+            user=other, conference=conference, discord_username="d"
+        )
+        VolunteerProfile.objects.create(
+            user=portal_user, conference=conference, discord_username="d"
+        )
+        client.force_login(portal_user)
+
+        response = client.get(reverse("volunteer:my_conferences"))
+
+        profiles = list(response.context["profiles"])
+        assert len(profiles) == 1
+        assert profiles[0].user == portal_user
+
+    def test_requires_login(self, client):
+        response = client.get(reverse("volunteer:my_conferences"))
+        assert response.status_code == 302

--- a/volunteer/urls.py
+++ b/volunteer/urls.py
@@ -8,6 +8,11 @@ app_name = "volunteer"
 urlpatterns = [
     path("", views.index, name="index"),
     path(
+        "my-conferences/",
+        login_required(views.MyConferencesView.as_view()),
+        name="my_conferences",
+    ),
+    path(
         "list",
         login_required(views.VolunteerProfileList.as_view()),
         name="volunteer_profile_list",

--- a/volunteer/views.py
+++ b/volunteer/views.py
@@ -42,6 +42,21 @@ def index(request):
     return render(request, "volunteer/index.html", context)
 
 
+class MyConferencesView(ListView):
+    """List every edition the logged-in volunteer has a profile for."""
+
+    template_name = "volunteer/my_conferences.html"
+    context_object_name = "profiles"
+
+    def get_queryset(self):
+        return (
+            VolunteerProfile.objects.filter(user=self.request.user)
+            .select_related("conference")
+            .prefetch_related("teams", "roles")
+            .order_by("-conference__year")
+        )
+
+
 class VolunteerAdminRequiredMixin(AdminRequiredMixin):
     """Mixin for views that require administrative permission for the volunteers.
     Currently it requires the user to be a superuser or staff member.


### PR DESCRIPTION
**Phase 10.** A per-user page where a volunteer can see every edition they've taken part in.

## What changed
- **`MyConferencesView`** (login required) at **`/volunteer/my-conferences/`** — lists `request.user`'s `VolunteerProfile`s across all editions, newest year first, with the **year, application status, teams, and roles** for each.
- **`templates/volunteer/my_conferences.html`** — the history table.
- Linked from the volunteer index under *Links and Resources*.

## How it fits
Pairs with bring-forward (#333): a returning volunteer can see "2024, 2025, …" at a glance. Scoped strictly to the logged-in user's own profiles.

## Tests
- Lists the user's editions newest-first; only shows the user's own profiles; requires login.
- **434 pass, 100% coverage**; black/isort/flake8/djlint(+lint) clean; no schema change.

## Multi-year remaining
- **11** — verification pass
- **12** — "Start a new year" wizard (#341), composing create + clone-teams + bring-forward + freeze + activate.

Refs #321