### PR TITLE
Add portal CRUD views for teams

### DIFF
--- a/portal/urls.py
+++ b/portal/urls.py
@@ -40,6 +40,11 @@ urlpatterns = [
         name="teams",
     ),
     path(
+        "teams/new/",
+        volunteer_view.TeamCreate.as_view(),
+        name="team_new",
+    ),
+    path(
         "chapters/",
         volunteer_view.PyladiesChaptersList.as_view(),
         name="chapters",
@@ -48,6 +53,16 @@ urlpatterns = [
         "teams/<int:pk>",
         volunteer_view.TeamView.as_view(),
         name="team_detail",
+    ),
+    path(
+        "teams/<int:pk>/edit/",
+        volunteer_view.TeamUpdate.as_view(),
+        name="team_edit",
+    ),
+    path(
+        "teams/<int:pk>/delete/",
+        volunteer_view.TeamDelete.as_view(),
+        name="team_delete",
     ),
     path("i18n/", include("django.conf.urls.i18n")),
     path(

--- a/templates/team/index.html
+++ b/templates/team/index.html
@@ -18,6 +18,11 @@
                 {% endfor %}
             </div>
         {% endif %}
+        <p>
+            <a href="{% url 'team_new' %}" class="btn btn-primary">
+                <i class="fa-solid fa-plus"></i> {% trans "New Team" %}
+            </a>
+        </p>
         <div class="row pt-2 row-cols-1 row-cols-md-3 g-4">
             {% for team in teams %}
                 <div class="col">

--- a/templates/team/team_confirm_delete.html
+++ b/templates/team/team_confirm_delete.html
@@ -1,0 +1,19 @@
+{% extends "portal/base.html" %}
+{% load i18n %}
+{% block content %}
+    <div class="container px-4 py-3">
+        <h1 class="display-6 pb-2 border-bottom">
+            {% trans "Delete Team" %}
+        </h1>
+        <p class="fs-5">
+            {% blocktrans with name=team.short_name year=team.conference.year %}Are you sure you want to delete the team "{{ name }}" ({{ year }})?{% endblocktrans %}
+        </p>
+        <form method="post">
+            {% csrf_token %}
+            <button type="submit" class="btn btn-danger">
+                {% trans "Delete" %}
+            </button>
+            <a href="{% url 'team_detail' team.pk %}" class="btn btn-secondary">{% trans "Cancel" %}</a>
+        </form>
+    </div>
+{% endblock content %}

--- a/templates/team/team_detail.html
+++ b/templates/team/team_detail.html
@@ -8,10 +8,15 @@
         <h2 class="pb-2 border-bottom">
             {{ team.short_name }}
             <span class="badge bg-secondary align-middle fs-6">{{ team.conference }}</span>
-            {% if user.is_superuser %}
-                <small class="fs-6"><a href="{% url 'admin:volunteer_team_change' team.id %}">Edit in Django Admin</a></small>
-            {% endif %}
         </h2>
+        {% if user.is_superuser or user.is_staff %}
+            <div class="mb-3">
+                <a href="{% url 'team_edit' team.id %}"
+                   class="btn btn-sm btn-outline-primary">{% trans "Edit" %}</a>
+                <a href="{% url 'team_delete' team.id %}"
+                   class="btn btn-sm btn-outline-danger">{% trans "Delete" %}</a>
+            </div>
+        {% endif %}
         <div class="row g-4 py-5 row-cols-1 row-cols-lg-3">
             {{ team.description }}
         </div>

--- a/templates/team/team_detail.html
+++ b/templates/team/team_detail.html
@@ -5,6 +5,9 @@
 {% endblock body %}
 {% block content %}
     <div class="container px-4 py-5" id="featured-3">
+        <p>
+            <a href="{% url 'teams' %}"><i class="fa-solid fa-arrow-left"></i> {% trans "All teams" %}</a>
+        </p>
         <h2 class="pb-2 border-bottom">
             {{ team.short_name }}
             <span class="badge bg-secondary align-middle fs-6">{{ team.conference }}</span>

--- a/templates/team/team_form.html
+++ b/templates/team/team_form.html
@@ -1,0 +1,27 @@
+{% extends "portal/base.html" %}
+{% load i18n %}
+{% load django_bootstrap5 %}
+{% block content %}
+    <div class="container px-4 py-3">
+        <h1 class="display-6 pb-2 border-bottom">
+            {% if form.instance.pk %}
+                {% trans "Edit Team" %}
+            {% else %}
+                {% trans "New Team" %}
+            {% endif %}
+        </h1>
+        <form method="post" class="col-md-8">
+            {% csrf_token %}
+            {% bootstrap_form form %}
+            <button type="submit" class="btn btn-primary">
+                {% trans "Save" %}
+            </button>
+            {% if form.instance.pk %}
+                <a href="{% url 'team_detail' form.instance.pk %}"
+                   class="btn btn-secondary">{% trans "Cancel" %}</a>
+            {% else %}
+                <a href="{% url 'teams' %}" class="btn btn-secondary">{% trans "Cancel" %}</a>
+            {% endif %}
+        </form>
+    </div>
+{% endblock content %}

--- a/tests/volunteer/test_views.py
+++ b/tests/volunteer/test_views.py
@@ -1229,3 +1229,61 @@ class TestTeamList:
             client.get(reverse("teams") + "?conference=99999").context["teams"]
         )
         assert active_team in teams
+
+
+@pytest.mark.django_db
+class TestTeamCRUD:
+    def test_create_team(self, client, admin_user, conference):
+        client.force_login(admin_user)
+        response = client.post(
+            reverse("team_new"),
+            {
+                "short_name": "Comms",
+                "description": "Communications",
+                "open_to_new_members": "on",
+            },
+            follow=True,
+        )
+        assert response.status_code == 200
+        team = Team.objects.get(short_name="Comms")
+        assert team.conference == conference  # the active edition
+        assert team.open_to_new_members is True
+
+    def test_update_team(self, client, admin_user, conference):
+        team = Team.objects.create(
+            short_name="Comms", description="old", conference=conference
+        )
+        client.force_login(admin_user)
+        response = client.post(
+            reverse("team_edit", kwargs={"pk": team.pk}),
+            {"short_name": "Comms", "description": "new description"},
+            follow=True,
+        )
+        assert response.status_code == 200
+        team.refresh_from_db()
+        assert team.description == "new description"
+        assert team.open_to_new_members is False  # unchecked
+
+    def test_delete_team(self, client, admin_user, conference):
+        team = Team.objects.create(
+            short_name="Comms", description="d", conference=conference
+        )
+        client.force_login(admin_user)
+        response = client.post(
+            reverse("team_delete", kwargs={"pk": team.pk}), follow=True
+        )
+        assert response.status_code == 200
+        assert not Team.objects.filter(pk=team.pk).exists()
+
+    def test_team_crud_requires_admin(self, client, portal_user, conference):
+        team = Team.objects.create(
+            short_name="Comms", description="d", conference=conference
+        )
+        client.force_login(portal_user)  # not staff/superuser
+        urls = [
+            reverse("team_new"),
+            reverse("team_edit", kwargs={"pk": team.pk}),
+            reverse("team_delete", kwargs={"pk": team.pk}),
+        ]
+        for url in urls:
+            assert client.get(url).status_code in (302, 403)

--- a/tests/volunteer/test_views.py
+++ b/tests/volunteer/test_views.py
@@ -1287,3 +1287,12 @@ class TestTeamCRUD:
         ]
         for url in urls:
             assert client.get(url).status_code in (302, 403)
+
+    def test_detail_has_back_to_teams_link(self, client, admin_user, conference):
+        team = Team.objects.create(
+            short_name="Comms", description="d", conference=conference
+        )
+        client.force_login(admin_user)
+        response = client.get(reverse("team_detail", kwargs={"pk": team.pk}))
+        assert response.status_code == 200
+        assert reverse("teams") in response.content.decode()

--- a/volunteer/forms.py
+++ b/volunteer/forms.py
@@ -321,3 +321,21 @@ class VolunteerProfileReviewForm(ModelForm):
             enqueue(send_volunteer_onboarding_email_task, volunteer_profile.id)
             enqueue(send_internal_volunteer_onboarding_email_task, volunteer_profile.id)
         return volunteer_profile
+
+
+class TeamForm(ModelForm):
+    """Create/edit a team through the portal (instead of Django admin)."""
+
+    class Meta:
+        model = Team
+        fields = ["short_name", "description", "open_to_new_members", "team_leads"]
+        widgets = {"team_leads": forms.CheckboxSelectMultiple}
+
+    def __init__(self, *args, conference=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Team leads must be volunteers of the team's own edition. The views
+        # always pass the edition (active on create, the instance's on edit).
+        self.fields["team_leads"].required = False
+        self.fields["team_leads"].queryset = VolunteerProfile.objects.filter(
+            conference=conference
+        )

--- a/volunteer/views.py
+++ b/volunteer/views.py
@@ -17,7 +17,7 @@ from common.mixins import AdminRequiredMixin, VolunteerOrAdminRequiredMixin
 from common.tasks import enqueue
 from portal.models import Conference
 
-from .forms import VolunteerProfileForm, VolunteerProfileReviewForm
+from .forms import TeamForm, VolunteerProfileForm, VolunteerProfileReviewForm
 from .models import (  # Language,
     ApplicationStatus,
     PyladiesChapter,
@@ -364,6 +364,45 @@ class TeamView(VolunteerAdminRequiredMixin, DetailView):
         except Team.DoesNotExist:
             return redirect("teams")
         return super(TeamView, self).get(request, pk)
+
+
+class TeamCreate(VolunteerAdminRequiredMixin, CreateView):
+    model = Team
+    form_class = TeamForm
+    template_name = "team/team_form.html"
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["conference"] = Conference.get_active()
+        return kwargs
+
+    def form_valid(self, form):
+        # New teams belong to the active edition.
+        form.instance.conference = Conference.get_active()
+        return super().form_valid(form)
+
+    def get_success_url(self):
+        return reverse("team_detail", kwargs={"pk": self.object.pk})
+
+
+class TeamUpdate(VolunteerAdminRequiredMixin, UpdateView):
+    model = Team
+    form_class = TeamForm
+    template_name = "team/team_form.html"
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["conference"] = self.object.conference
+        return kwargs
+
+    def get_success_url(self):
+        return reverse("team_detail", kwargs={"pk": self.object.pk})
+
+
+class TeamDelete(VolunteerAdminRequiredMixin, DeleteView):
+    model = Team
+    template_name = "team/team_confirm_delete.html"
+    success_url = reverse_lazy("teams")
 
 
 class ResendOnboardingEmailView(VolunteerAdminRequiredMixin, View):


### PR DESCRIPTION
First of the "manage things without Django admin" set. Teams can now be created, edited, and deleted from the portal.

## What changed
- **`TeamForm`** + **`TeamCreate` / `TeamUpdate` / `TeamDelete`** (staff/superuser).
  - New teams are scoped to the **active edition**.
  - The **team-leads picker is scoped** to the team's own edition (only that year's volunteers).
- **`/teams/new/`**, **`/teams/<pk>/edit/`**, **`/teams/<pk>/delete/`**.
- "New Team" button on the teams list; "Edit"/"Delete" buttons on team detail, **replacing the "Edit in Django Admin" link**; delete confirmation page.

## Tests
- Create (lands in active edition), update (incl. the open-to-new-members checkbox), delete, and admin-only gating.
- **441 pass, 100% coverage**; black/isort/flake8/djlint clean; no schema change.

## Follow-ups (this series)
- PR 2 — Sponsorship edit/delete (replace the list's "Update → admin").
- PR 3 — Conference list + edit + landing reorg; guarded Conference delete.

Refs #321