### PR TITLE
Add portal edit/delete views for sponsorships

### DIFF
--- a/sponsorship/forms.py
+++ b/sponsorship/forms.py
@@ -68,10 +68,15 @@ class SponsorshipProfileForm(forms.ModelForm):
         # (e.g. to set up next year's sponsors early).
         if not self.instance.pk:
             self.fields["conference"].initial = active
-        # Offer only the active edition's tiers (tiers are conference-scoped);
-        # otherwise the dropdown lists every year's tiers.
+        # Offer only the relevant edition's tiers (tiers are conference-scoped);
+        # when editing, that's the sponsor's own edition, otherwise the active
+        # one — instead of listing every year's tiers.
+        if self.instance.conference_id:
+            tier_conference = self.instance.conference
+        else:
+            tier_conference = active
         self.fields["sponsorship_tier"].queryset = SponsorshipTier.objects.filter(
-            conference=active
+            conference=tier_conference
         )
 
     def clean(self):

--- a/sponsorship/templates/sponsorship/sponsorship_profile_confirm_delete.html
+++ b/sponsorship/templates/sponsorship/sponsorship_profile_confirm_delete.html
@@ -1,0 +1,20 @@
+{% extends "portal/base.html" %}
+{% load i18n %}
+{% block content %}
+    <div class="container px-4 py-3">
+        <h1 class="display-6 pb-2 border-bottom">
+            {% trans "Delete Sponsorship" %}
+        </h1>
+        <p class="fs-5">
+            {% blocktrans with name=profile.organization_name year=profile.conference.year %}Are you sure you want to delete the sponsorship "{{ name }}" ({{ year }})?{% endblocktrans %}
+        </p>
+        <form method="post">
+            {% csrf_token %}
+            <button type="submit" class="btn btn-danger">
+                {% trans "Delete" %}
+            </button>
+            <a href="{% url 'sponsorship:sponsorship_profile_detail' profile.pk %}"
+               class="btn btn-secondary">{% trans "Cancel" %}</a>
+        </form>
+    </div>
+{% endblock content %}

--- a/sponsorship/templates/sponsorship/sponsorship_profile_detail.html
+++ b/sponsorship/templates/sponsorship/sponsorship_profile_detail.html
@@ -25,9 +25,9 @@
                             {% if user.is_superuser or user.is_staff %}
                                 <div class="mb-2">
                                     <a href="{% url 'sponsorship:sponsorship_profile_edit' profile.pk %}"
-                                       class="btn btn-sm btn-outline-primary">{% trans "Edit" %}</a>
+                                       class="btn btn-sm btn-outline-primary"><i class="fa-solid fa-pencil"></i> {% trans "Edit" %}</a>
                                     <a href="{% url 'sponsorship:sponsorship_profile_delete' profile.pk %}"
-                                       class="btn btn-sm btn-outline-danger">{% trans "Delete" %}</a>
+                                       class="btn btn-sm btn-outline-danger"><i class="fa-solid fa-trash"></i> {% trans "Delete" %}</a>
                                 </div>
                             {% endif %}
                             <p class="card-text">

--- a/sponsorship/templates/sponsorship/sponsorship_profile_detail.html
+++ b/sponsorship/templates/sponsorship/sponsorship_profile_detail.html
@@ -22,6 +22,14 @@
                                 {{ profile.organization_name }}
                                 <span class="badge bg-secondary align-middle fs-6">{{ profile.conference }}</span>
                             </h5>
+                            {% if user.is_superuser or user.is_staff %}
+                                <div class="mb-2">
+                                    <a href="{% url 'sponsorship:sponsorship_profile_edit' profile.pk %}"
+                                       class="btn btn-sm btn-outline-primary">{% trans "Edit" %}</a>
+                                    <a href="{% url 'sponsorship:sponsorship_profile_delete' profile.pk %}"
+                                       class="btn btn-sm btn-outline-danger">{% trans "Delete" %}</a>
+                                </div>
+                            {% endif %}
                             <p class="card-text">
                                 {{ profile.company_description }}
                             </p>

--- a/sponsorship/templates/sponsorship/sponsorship_profile_form.html
+++ b/sponsorship/templates/sponsorship/sponsorship_profile_form.html
@@ -24,7 +24,7 @@
         </p>
         <div class="row g-5">
             {% bootstrap_form_errors form %}
-            <form action="{% if object.pk %}{#  url 'sponsorship:sponsorship_profile_edit' object.pk #}{% else %}{% url 'sponsorship:sponsorship_profile_new' %}{% endif %}"
+            <form action="{% if object.pk %}{% url 'sponsorship:sponsorship_profile_edit' object.pk %}{% else %}{% url 'sponsorship:sponsorship_profile_new' %}{% endif %}"
                   method="post"
                   class="form">
                 {% csrf_token %}

--- a/sponsorship/templates/sponsorship/sponsorship_profile_form.html
+++ b/sponsorship/templates/sponsorship/sponsorship_profile_form.html
@@ -58,12 +58,12 @@
                             Create Profile
                         {% endif %}
                     </button>
-                    {# {% if object.pk %}#}
-                    {# <a href="{% url 'sponsorship:volunteer_profile_detail' object.pk %}" #}
-                    {# class="btn btn-secondary">Cancel</a>#}
-                    {# {% else %}#}
-                    {# <a href="{% url 'volunteer:index' %}" class="btn btn-secondary">Cancel</a>#}
-                    {# {% endif %}#}
+                    {% if object.pk %}
+                        <a href="{% url 'sponsorship:sponsorship_profile_detail' object.pk %}"
+                           class="btn btn-secondary">Cancel</a>
+                    {% endif %}
+                    <a href="{% url 'sponsorship:sponsorship_list' %}"
+                       class="btn btn-outline-secondary">All sponsors</a>
                 </div>
             </form>
         </div>

--- a/sponsorship/urls.py
+++ b/sponsorship/urls.py
@@ -21,6 +21,16 @@ urlpatterns = [
         name="sponsorship_profile_detail",
     ),
     path(
+        "<int:pk>/edit/",
+        views.SponsorshipProfileUpdate.as_view(),
+        name="sponsorship_profile_edit",
+    ),
+    path(
+        "<int:pk>/delete/",
+        views.SponsorshipProfileDelete.as_view(),
+        name="sponsorship_profile_delete",
+    ),
+    path(
         "<int:pk>/send-invoice/",
         views.SponsorshipProfileSendInvoice.as_view(),
         name="sponsorship_send_invoice",

--- a/sponsorship/views.py
+++ b/sponsorship/views.py
@@ -8,7 +8,7 @@ from django.urls import reverse_lazy
 from django.utils.html import format_html
 from django.views.generic import DetailView
 from django.views.generic.base import View
-from django.views.generic.edit import CreateView
+from django.views.generic.edit import CreateView, DeleteView, UpdateView
 from django_filters.views import FilterView
 from django_tables2.views import SingleTableMixin
 
@@ -58,6 +58,26 @@ class SponsorshipProfileCreate(AdminRequiredMixin, CreateView):
         kwargs = super(SponsorshipProfileCreate, self).get_form_kwargs()
         kwargs.update({"user": self.request.user})
         return kwargs
+
+
+class SponsorshipProfileUpdate(AdminRequiredMixin, UpdateView):
+    model = SponsorshipProfile
+    template_name = "sponsorship/sponsorship_profile_form.html"
+    form_class = SponsorshipProfileForm
+
+    # No ``user`` kwarg passed to the form: editing must not reassign the owner.
+
+    def get_success_url(self):
+        return reverse_lazy(
+            "sponsorship:sponsorship_profile_detail", kwargs={"pk": self.object.pk}
+        )
+
+
+class SponsorshipProfileDelete(AdminRequiredMixin, DeleteView):
+    model = SponsorshipProfile
+    template_name = "sponsorship/sponsorship_profile_confirm_delete.html"
+    context_object_name = "profile"
+    success_url = reverse_lazy("sponsorship:sponsorship_list")
 
 
 class SponsorshipProfileTable(tables.Table):
@@ -156,11 +176,16 @@ class SponsorshipProfileTable(tables.Table):
         """Render action buttons for each sponsorship profile."""
 
         edit_url = reverse_lazy(
-            "admin:sponsorship_sponsorshipprofile_change", args=[record.pk]
+            "sponsorship:sponsorship_profile_edit", args=[record.pk]
+        )
+        delete_url = reverse_lazy(
+            "sponsorship:sponsorship_profile_delete", args=[record.pk]
         )
         return format_html(
-            '<a href="{}" class="btn btn-sm btn-primary">Update</a>',
+            '<a href="{}" class="btn btn-sm btn-primary">Update</a> '
+            '<a href="{}" class="btn btn-sm btn-outline-danger">Delete</a>',
             edit_url,
+            delete_url,
         )
 
     def render_github_issue_url(self, value, record):

--- a/sponsorship/views.py
+++ b/sponsorship/views.py
@@ -181,9 +181,12 @@ class SponsorshipProfileTable(tables.Table):
         delete_url = reverse_lazy(
             "sponsorship:sponsorship_profile_delete", args=[record.pk]
         )
+        # Icon-only in the table (tooltip + aria-label for accessibility).
         return format_html(
-            '<a href="{}" class="btn btn-sm btn-primary">Update</a> '
-            '<a href="{}" class="btn btn-sm btn-outline-danger">Delete</a>',
+            '<a href="{}" class="btn btn-sm btn-primary" title="Edit" '
+            'aria-label="Edit"><i class="fa-solid fa-pencil"></i></a> '
+            '<a href="{}" class="btn btn-sm btn-outline-danger" title="Delete" '
+            'aria-label="Delete"><i class="fa-solid fa-trash"></i></a>',
             edit_url,
             delete_url,
         )

--- a/tests/sponsorship/test_forms.py
+++ b/tests/sponsorship/test_forms.py
@@ -3,6 +3,7 @@ import pytest
 from portal.models import Conference
 from sponsorship.forms import SponsorshipProfileForm
 from sponsorship.models import (
+    SponsorshipProfile,
     SponsorshipProgressStatus,
     SponsorshipTier,
 )
@@ -172,3 +173,25 @@ class TestSponsorshipProfileForm:
         assert profile.company_description == form_data["company_description"]
         assert profile.progress_status == form_data["progress_status"]
         assert profile.po_number == form_data["po_number"]
+
+    def test_edit_scopes_tiers_to_sponsors_edition(self, conference):
+        past = Conference.objects.create(
+            year=2024, name="PyLadiesCon 2024", slug="2024"
+        )
+        past_tier = SponsorshipTier.objects.create(
+            conference=past, name="Old", amount=1, description="d"
+        )
+        active_tier = SponsorshipTier.objects.create(
+            conference=conference, name="New", amount=2, description="d"
+        )
+        profile = SponsorshipProfile.objects.create(
+            organization_name="Acme",
+            conference=past,
+            progress_status=SponsorshipProgressStatus.AWAITING_RESPONSE,
+        )
+
+        form = SponsorshipProfileForm(instance=profile)
+        tiers = list(form.fields["sponsorship_tier"].queryset)
+
+        assert past_tier in tiers  # the sponsor's own edition
+        assert active_tier not in tiers

--- a/tests/sponsorship/test_views.py
+++ b/tests/sponsorship/test_views.py
@@ -713,3 +713,54 @@ class TestSponsorshipCreateViews:
         assert "Invoice request sent to PSF accounting team for Test Corp" in str(
             messages[0].message
         )
+
+
+@pytest.mark.django_db
+class TestSponsorshipCRUD:
+    def _sponsor(self, conference, **kwargs):
+        return SponsorshipProfile.objects.create(
+            organization_name=kwargs.pop("organization_name", "Acme"),
+            conference=conference,
+            progress_status=SponsorshipProgressStatus.AWAITING_RESPONSE,
+            **kwargs,
+        )
+
+    def test_admin_can_edit_sponsor(self, client, admin_user, portal_user, conference):
+        profile = self._sponsor(conference, user=portal_user)
+        client.force_login(admin_user)
+        response = client.post(
+            reverse("sponsorship:sponsorship_profile_edit", kwargs={"pk": profile.pk}),
+            {
+                "organization_name": "Acme Updated",
+                "conference": conference.pk,
+                "main_contact_user": admin_user.pk,
+                "progress_status": SponsorshipProgressStatus.AWAITING_RESPONSE.value,
+            },
+            follow=True,
+        )
+        assert response.status_code == 200
+        profile.refresh_from_db()
+        assert profile.organization_name == "Acme Updated"
+        assert profile.user == portal_user  # owner is not reassigned on edit
+
+    def test_admin_can_delete_sponsor(self, client, admin_user, conference):
+        profile = self._sponsor(conference)
+        client.force_login(admin_user)
+        response = client.post(
+            reverse(
+                "sponsorship:sponsorship_profile_delete", kwargs={"pk": profile.pk}
+            ),
+            follow=True,
+        )
+        assert response.status_code == 200
+        assert not SponsorshipProfile.objects.filter(pk=profile.pk).exists()
+
+    def test_edit_delete_require_admin(self, client, portal_user, conference):
+        profile = self._sponsor(conference)
+        client.force_login(portal_user)  # not staff/superuser
+        for name in [
+            "sponsorship:sponsorship_profile_edit",
+            "sponsorship:sponsorship_profile_delete",
+        ]:
+            url = reverse(name, kwargs={"pk": profile.pk})
+            assert client.get(url).status_code in (302, 403)

--- a/tests/sponsorship/test_views.py
+++ b/tests/sponsorship/test_views.py
@@ -418,7 +418,12 @@ class TestSponsorshipViews:
         sponsors_table = response.context["table"]
         action_button = sponsors_table.render_actions("", profile)
         assert "btn-primary" in action_button
-        assert "Update" in action_button
+        assert "fa-pencil" in action_button  # edit icon
+        assert "fa-trash" in action_button  # delete icon
+        assert (
+            reverse("sponsorship:sponsorship_profile_edit", args=[profile.pk])
+            in action_button
+        )
 
     def test_sponsors_table_render_github_issue_url(
         self, client, admin_user, conference
@@ -764,3 +769,12 @@ class TestSponsorshipCRUD:
         ]:
             url = reverse(name, kwargs={"pk": profile.pk})
             assert client.get(url).status_code in (302, 403)
+
+    def test_edit_page_links_back_to_list(self, client, admin_user, conference):
+        profile = self._sponsor(conference)
+        client.force_login(admin_user)
+        response = client.get(
+            reverse("sponsorship:sponsorship_profile_edit", kwargs={"pk": profile.pk})
+        )
+        assert response.status_code == 200
+        assert reverse("sponsorship:sponsorship_list") in response.content.decode()


### PR DESCRIPTION
PR 2 of the "manage things without Django admin" series. Sponsorships can now be **edited and deleted from the portal** (create already existed).

## What changed
- **`SponsorshipProfileUpdate` / `SponsorshipProfileDelete`** (staff/superuser, matching the existing create view).
  - Update reuses `SponsorshipProfileForm` and **does not pass `user`**, so editing never reassigns the profile's owner.
  - The form now scopes the **tier dropdown to the sponsor's own edition** when editing (active edition on create).
- The list's **"Update" action now links to the portal edit view** (was Django admin) and gains a **Delete** button; the **detail page** gets Edit/Delete buttons (staff/superuser).

## Tests
- Edit (saves changes, owner preserved), delete, admin-only gating; form tier-scoping on edit.
- **462 pass, 100% coverage**; black/isort/flake8/djlint clean; no schema change.

## Remaining in the series
- **PR 3 — Conference list/edit + landing reorg** (with the guarded delete).

Refs #321