### PR TITLE
Use action icons across the volunteer table and detail pages

### DIFF
--- a/templates/volunteer/my_conferences.html
+++ b/templates/volunteer/my_conferences.html
@@ -55,7 +55,9 @@
                             </td>
                             <td>
                                 <a href="{% url 'volunteer:volunteer_profile_detail' profile.id %}"
-                                   class="btn btn-sm btn-outline-primary">{% trans "View" %}</a>
+                                   class="btn btn-sm btn-outline-primary"
+                                   title="View"
+                                   aria-label="View"><i class="fa-solid fa-eye"></i></a>
                             </td>
                         </tr>
                     {% endfor %}

--- a/templates/volunteer/volunteerprofile_detail.html
+++ b/templates/volunteer/volunteerprofile_detail.html
@@ -225,27 +225,27 @@
     <div class="mt-4">
         {% if user.is_superuser and user.username != object.user.username %}
             <a class="btn btn-secondary"
-               href="{% url 'volunteer:volunteers_list' %}">Back to Manage Volunteers</a>
+               href="{% url 'volunteer:volunteers_list' %}"><i class="fa-solid fa-arrow-left"></i> Back to Manage Volunteers</a>
             {% if object.application_status != "Cancelled" %}
                 <button type="button"
                         class="btn btn-danger ms-2"
                         data-bs-toggle="modal"
                         data-bs-target="#cancelVolunteeringModal">
-                    Cancel Volunteering
+                    <i class="fa-solid fa-ban"></i> Cancel Volunteering
                 </button>
             {% endif %}
         {% else %}
             {% if object.application_status != "Cancelled" %}
                 <a class="btn btn-primary"
-                   href="{% url 'volunteer:volunteer_profile_edit' object.pk %}">Edit Profile</a>
+                   href="{% url 'volunteer:volunteer_profile_edit' object.pk %}"><i class="fa-solid fa-pencil"></i> Edit Profile</a>
                 <button type="button"
                         class="btn btn-danger ms-2"
                         data-bs-toggle="modal"
                         data-bs-target="#cancelVolunteeringModal">
-                    Cancel My Volunteering
+                    <i class="fa-solid fa-ban"></i> Cancel My Volunteering
                 </button>
             {% endif %}
-            <a class="btn btn-secondary" href="{% url 'volunteer:index' %}">Back to Volunteer Dashboard</a>
+            <a class="btn btn-secondary" href="{% url 'volunteer:index' %}"><i class="fa-solid fa-arrow-left"></i> Back to Volunteer Dashboard</a>
         {% endif %}
     </div>
     <!-- Cancel Volunteering Modal -->

--- a/volunteer/views.py
+++ b/volunteer/views.py
@@ -156,11 +156,15 @@ class VolunteerProfileTable(tables.Table):
             ApplicationStatus.WAITLISTED,
         ]:
             render_html = format_html(
-                '<a href="{}" class="btn btn-sm btn-primary">Review</a> ', url
+                '<a href="{}" class="btn btn-sm btn-primary" title="Review" '
+                'aria-label="Review"><i class="fa-solid fa-clipboard-list"></i></a> ',
+                url,
             )
         elif application_status == ApplicationStatus.APPROVED:
             render_html = format_html(
-                '<a href="{}" class="btn btn-sm btn-info">Manage</a> ', url
+                '<a href="{}" class="btn btn-sm btn-info" title="Manage" '
+                'aria-label="Manage"><i class="fa-solid fa-gear"></i></a> ',
+                url,
             )
         return render_html
 


### PR DESCRIPTION
Extends the icon convention (started on the sponsorship pages, #361) to the rest of the tables/detail pages.

## What changed
- **Volunteer list table**: Review / Manage actions are now **icon-only** (clipboard / gear) with `title` + `aria-label`.
- **Volunteer profile detail**: action buttons gain icons (pencil for Edit, ban for Cancel, arrow for Back) — **icon + text** on the detail page.
- **"Your Conferences" table**: the per-row View is now an **icon-only** eye button with tooltip.

## Convention (now consistent across sponsorship, team, volunteer)
| Place | Style |
|---|---|
| List tables | icon-only + `title`/`aria-label` |
| Detail pages | icon + text |

## Tests
- Existing `render_actions` tests still pass (Review/Manage now carried in the `title`).
- **463 pass, 100% coverage**; black/isort/flake8/djlint clean.

Refs #321