### PR TITLE
Add portal list/edit/delete views for conferences

### DIFF
--- a/portal/forms.py
+++ b/portal/forms.py
@@ -73,3 +73,34 @@ class StartNewYearForm(forms.Form):
         if Conference.objects.filter(slug=slug).exists():
             raise forms.ValidationError("A conference with that slug already exists.")
         return slug
+
+
+class ConferenceForm(forms.ModelForm):
+    """Edit an existing conference edition through the portal."""
+
+    class Meta:
+        model = Conference
+        fields = [
+            "year",
+            "name",
+            "slug",
+            "is_active",
+            "pretix_event_slug",
+            "sponsorship_goal",
+            "donation_goal",
+            "proposals_count",
+            "volunteer_application_open",
+            "sponsorship_open",
+            "accepting_donations",
+            "start_date",
+            "end_date",
+            "conference_date",
+            "banner_text",
+        ]
+        widgets = {
+            "start_date": forms.DateInput(attrs={"type": "date"}, format="%Y-%m-%d"),
+            "end_date": forms.DateInput(attrs={"type": "date"}, format="%Y-%m-%d"),
+            "conference_date": forms.DateInput(
+                attrs={"type": "date"}, format="%Y-%m-%d"
+            ),
+        }

--- a/portal/urls.py
+++ b/portal/urls.py
@@ -90,4 +90,19 @@ urlpatterns = [
         views.StartNewYearView.as_view(),
         name="start_new_year",
     ),
+    path(
+        "conferences/",
+        views.ConferenceList.as_view(),
+        name="conference_list",
+    ),
+    path(
+        "conferences/<int:pk>/edit/",
+        views.ConferenceUpdate.as_view(),
+        name="conference_edit",
+    ),
+    path(
+        "conferences/<int:pk>/delete/",
+        views.ConferenceDelete.as_view(),
+        name="conference_delete",
+    ),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/portal/views.py
+++ b/portal/views.py
@@ -1,13 +1,15 @@
 from django.contrib import messages
 from django.contrib.auth import get_user
+from django.db.models import ProtectedError
 from django.http import JsonResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse_lazy
-from django.views.generic.edit import FormView
+from django.views.generic import ListView
+from django.views.generic.edit import DeleteView, FormView, UpdateView
 
 from common.mixins import SuperuserRequiredMixin
 from portal.common import get_historical_comparison_data, get_stats_cached_values
-from portal.forms import StartNewYearForm
+from portal.forms import ConferenceForm, StartNewYearForm
 from portal.models import Conference
 from portal.services import (
     bring_forward_volunteers,
@@ -163,3 +165,36 @@ class StartNewYearView(SuperuserRequiredMixin, FormView):
             message += " It is now the active edition."
         messages.success(self.request, message)
         return super().form_valid(form)
+
+
+class ConferenceList(SuperuserRequiredMixin, ListView):
+    model = Conference
+    template_name = "portal/conference_list.html"
+    context_object_name = "conferences"
+
+
+class ConferenceUpdate(SuperuserRequiredMixin, UpdateView):
+    model = Conference
+    form_class = ConferenceForm
+    template_name = "portal/conference_form.html"
+    success_url = reverse_lazy("conference_list")
+
+
+class ConferenceDelete(SuperuserRequiredMixin, DeleteView):
+    model = Conference
+    template_name = "portal/conference_confirm_delete.html"
+    context_object_name = "conference"
+    success_url = reverse_lazy("conference_list")
+
+    def form_valid(self, form):
+        # An edition referenced by teams/profiles/sponsors/tiers/donations is
+        # PROTECTed; surface a clear message instead of a 500.
+        try:
+            return super().form_valid(form)
+        except ProtectedError:
+            messages.error(
+                self.request,
+                f"Cannot delete {self.object}: it still has teams, volunteers, "
+                "sponsors, tiers, or donations. Remove those first.",
+            )
+            return redirect("conference_list")

--- a/templates/portal/conference_confirm_delete.html
+++ b/templates/portal/conference_confirm_delete.html
@@ -1,0 +1,22 @@
+{% extends "portal/base.html" %}
+{% load i18n %}
+{% block content %}
+    <div class="container px-4 py-3">
+        <h1 class="display-6 pb-2 border-bottom">
+            {% trans "Delete Conference" %}
+        </h1>
+        <p class="fs-5">
+            {% blocktrans with name=conference.name %}Are you sure you want to delete "{{ name }}"?{% endblocktrans %}
+        </p>
+        <p class="text-muted">
+            {% trans "Editions with teams, volunteers, sponsors, tiers, or donations cannot be deleted." %}
+        </p>
+        <form method="post">
+            {% csrf_token %}
+            <button type="submit" class="btn btn-danger">
+                {% trans "Delete" %}
+            </button>
+            <a href="{% url 'conference_list' %}" class="btn btn-secondary">{% trans "Cancel" %}</a>
+        </form>
+    </div>
+{% endblock content %}

--- a/templates/portal/conference_form.html
+++ b/templates/portal/conference_form.html
@@ -1,0 +1,21 @@
+{% extends "portal/base.html" %}
+{% load i18n %}
+{% load django_bootstrap5 %}
+{% block content %}
+    <div class="container px-4 py-3">
+        <p>
+            <a href="{% url 'conference_list' %}"><i class="fa-solid fa-arrow-left"></i> {% trans "All conferences" %}</a>
+        </p>
+        <h1 class="display-6 pb-2 border-bottom">
+            {% trans "Edit Conference" %}: {{ object.name }}
+        </h1>
+        <form method="post" class="col-md-8">
+            {% csrf_token %}
+            {% bootstrap_form form %}
+            <button type="submit" class="btn btn-primary">
+                {% trans "Save" %}
+            </button>
+            <a href="{% url 'conference_list' %}" class="btn btn-secondary">{% trans "Cancel" %}</a>
+        </form>
+    </div>
+{% endblock content %}

--- a/templates/portal/conference_list.html
+++ b/templates/portal/conference_list.html
@@ -1,0 +1,59 @@
+{% extends "portal/base.html" %}
+{% load i18n %}
+{% block content %}
+    <div class="container px-4 py-3">
+        <h1 class="display-6 pb-2 border-bottom">
+            {% trans "Conferences" %}
+        </h1>
+        <table class="table table-hover align-middle">
+            <thead class="table-light">
+                <tr>
+                    <th>
+                        {% trans "Year" %}
+                    </th>
+                    <th>
+                        {% trans "Name" %}
+                    </th>
+                    <th>
+                        {% trans "Active" %}
+                    </th>
+                    <th>
+                        {% trans "Date" %}
+                    </th>
+                    <th>
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for conference in conferences %}
+                    <tr>
+                        <td>
+                            {{ conference.year }}
+                        </td>
+                        <td>
+                            {{ conference.name }}
+                        </td>
+                        <td>
+                            {% if conference.is_active %}
+                                <span class="badge bg-success">{% trans "Active" %}</span>
+                            {% endif %}
+                        </td>
+                        <td>
+                            {{ conference.conference_date|default:"" }}
+                        </td>
+                        <td>
+                            <a href="{% url 'conference_edit' conference.pk %}"
+                               class="btn btn-sm btn-outline-primary"
+                               title="Edit"
+                               aria-label="Edit"><i class="fa-solid fa-pencil"></i></a>
+                            <a href="{% url 'conference_delete' conference.pk %}"
+                               class="btn btn-sm btn-outline-danger"
+                               title="Delete"
+                               aria-label="Delete"><i class="fa-solid fa-trash"></i></a>
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+{% endblock content %}

--- a/templates/portal/index.html
+++ b/templates/portal/index.html
@@ -163,6 +163,25 @@
                             </li>
                         </ul>
                     </div>
+                    <div class="feature col">
+                        <div class="d-inline-flex align-items-center justify-content-center fa-3x mb-3">
+                            <i class="fa-solid fa-calendar-days"></i>
+                        </div>
+                        <h3 class="fs-2 text-body-emphasis">
+                            Manage Conferences
+                        </h3>
+                        <p>
+                            View, edit, and manage all conference editions.
+                        </p>
+                        <ul class="list-unstyled ps-8">
+                            <li>
+                                <a href="{% url 'conference_list' %}" class="icon-link">
+                                    {% translate "Manage Conferences" %}
+                                    <i class="fa-solid fa-chevron-right"></i>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
                     {% if can_start_next_year %}
                         <div class="feature col">
                             <div class="d-inline-flex align-items-center justify-content-center fa-3x mb-3">

--- a/tests/portal/test_views.py
+++ b/tests/portal/test_views.py
@@ -288,3 +288,63 @@ class TestStartNextYearGate:
         client.force_login(admin_user)
         response = client.get(reverse("index"))
         assert "Start Next Year's Conference" not in response.content.decode()
+
+
+@pytest.mark.django_db
+class TestConferenceCRUD:
+    def test_list_shows_conferences(self, client, admin_user, conference):
+        client.force_login(admin_user)
+        response = client.get(reverse("conference_list"))
+        assert response.status_code == 200
+        assert conference in response.context["conferences"]
+
+    def test_update_conference(self, client, admin_user, conference):
+        client.force_login(admin_user)
+        response = client.post(
+            reverse("conference_edit", kwargs={"pk": conference.pk}),
+            {
+                "year": conference.year,
+                "name": "Renamed Edition",
+                "slug": conference.slug,
+                "sponsorship_goal": "15000",
+                "donation_goal": "2500",
+                "proposals_count": "0",
+                "conference_date": "2025-11-15",
+            },
+            follow=True,
+        )
+        assert response.status_code == 200
+        conference.refresh_from_db()
+        assert conference.name == "Renamed Edition"
+        assert str(conference.conference_date) == "2025-11-15"
+
+    def test_delete_empty_conference(self, client, admin_user, conference):
+        extra = Conference.objects.create(year=2099, name="Empty", slug="empty")
+        client.force_login(admin_user)
+        response = client.post(
+            reverse("conference_delete", kwargs={"pk": extra.pk}), follow=True
+        )
+        assert response.status_code == 200
+        assert not Conference.objects.filter(pk=extra.pk).exists()
+
+    def test_delete_blocked_when_has_data(self, client, admin_user, conference):
+        extra = Conference.objects.create(year=2099, name="HasData", slug="hasdata")
+        Team.objects.create(conference=extra, short_name="T", description="d")
+        client.force_login(admin_user)
+        response = client.post(
+            reverse("conference_delete", kwargs={"pk": extra.pk}), follow=True
+        )
+        assert response.status_code == 200
+        assert Conference.objects.filter(pk=extra.pk).exists()  # protected, not deleted
+        assert "Cannot delete" in response.content.decode()
+
+    def test_requires_superuser(self, client, django_user_model, conference):
+        staff = django_user_model.objects.create_user("staffy2", is_staff=True)
+        client.force_login(staff)
+        urls = [
+            reverse("conference_list"),
+            reverse("conference_edit", kwargs={"pk": conference.pk}),
+            reverse("conference_delete", kwargs={"pk": conference.pk}),
+        ]
+        for url in urls:
+            assert client.get(url).status_code in (302, 403)


### PR DESCRIPTION
Final piece of the "manage things without Django admin" series. Conferences can now be **listed and edited** in the portal (create already exists via the Start-a-new-year wizard).

## What changed
- **`ConferenceList` / `ConferenceUpdate` / `ConferenceDelete`** — **superuser-only** (matching the wizard, since these manage editions).
- **Edit form** covers the year-config fields, including the new **`conference_date`** (with date pickers).
- **Guarded delete**: an edition referenced by teams/volunteers/sponsors/tiers/donations is PROTECTed, so deletion shows a **clear "cannot delete" message** instead of a 500.
- **Landing page**: new **"Manage Conferences"** card (superuser section); the list table uses the **icon-only** edit/delete convention.

## Usage
Dashboard (superuser) → **Manage Conferences** → edit any edition, or delete an empty one.

## Tests
- List, update (incl. setting `conference_date`), delete-empty (succeeds), delete-with-data (blocked + message), superuser-only gating.
- **468 pass, 100% coverage**; black/isort/flake8/djlint clean; no schema change.

Refs #321