### PR TITLE
Render the teams list as a table + add Manage Teams dashboard card

### DIFF
--- a/templates/portal/index.html
+++ b/templates/portal/index.html
@@ -126,6 +126,25 @@
                     </div>
                     <div class="feature col">
                         <div class="d-inline-flex align-items-center justify-content-center fa-3x mb-3">
+                            <i class="fa-solid fa-people-group"></i>
+                        </div>
+                        <h3 class="fs-2 text-body-emphasis">
+                            Manage Teams
+                        </h3>
+                        <p>
+                            Create and manage the conference teams and their leads.
+                        </p>
+                        <ul class="list-unstyled ps-8">
+                            <li>
+                                <a href="{% url 'teams' %}" class="icon-link">
+                                    {% translate "Manage Teams" %}
+                                    <i class="fa-solid fa-chevron-right"></i>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="feature col">
+                        <div class="d-inline-flex align-items-center justify-content-center fa-3x mb-3">
                             <i class="fa-solid fa-money-bill-trend-up"></i>
                         </div>
                         <h3 class="fs-2 text-body-emphasis">

--- a/templates/team/index.html
+++ b/templates/team/index.html
@@ -5,8 +5,9 @@
 {% endblock body %}
 {% block content %}
     <div class="container px-4 py-5" id="featured-3">
-        <h1 class="pb-2 border-bottom">
+        <h1 class="display-5">
             {% trans "Teams" %} — {{ selected_conference.year }}
+            <a class="btn btn-primary" href="{% url 'team_new' %}">{% trans "New Team" %}</a>
         </h1>
         {% if conferences %}
             <div class="btn-group mb-3" role="group" aria-label="Conference year">
@@ -18,11 +19,6 @@
                 {% endfor %}
             </div>
         {% endif %}
-        <p>
-            <a href="{% url 'team_new' %}" class="btn btn-primary">
-                <i class="fa-solid fa-plus"></i> {% trans "New Team" %}
-            </a>
-        </p>
         <table class="table table-hover align-middle">
             <thead class="table-light">
                 <tr>

--- a/templates/team/index.html
+++ b/templates/team/index.html
@@ -23,33 +23,59 @@
                 <i class="fa-solid fa-plus"></i> {% trans "New Team" %}
             </a>
         </p>
-        <div class="row pt-2 row-cols-1 row-cols-md-3 g-4">
-            {% for team in teams %}
-                <div class="col">
-                    <div class="card h-100">
-                        <div class="card-header">
-                            <h5>
-                                <a href="{% url 'team_detail' team.id %}">{{ team.short_name }}</a>
-                                <span class="badge bg-secondary">{{ team.conference.year }}</span>
-                            </h5>
-                        </div>
-                        <div class="card-body">
-                            <p class="card-text">
-                                {{ team.description | truncatechars:50 }}
-                            </p>
-                            <p class="card-text">
-                                <span class="badge bg-warning rounded-pill">{{ team.pending_members.count }}</span> <a href="{% url 'team_detail' team.id %}#pending-members">pending {{ team.pending_members.count|pluralize:"member, members" }}</a>
-                            </p>
-                            <p class="card-text">
-                                <span class="badge bg-warning rounded-pill">{{ team.waitlisted_members.count }}</span> <a href="{% url 'team_detail' team.id %}#waitlisted-members">waitlisted {{ team.waitlisted_members.count|pluralize:"member, members" }}</a>
-                            </p>
-                            <p class="card-text">
-                                <span class="badge bg-primary rounded-pill">{{ team.approved_members.count }}</span> <a href="{% url 'team_detail' team.id %}#approved-members">approved {{ team.approved_members.count|pluralize:"member, members" }}</a>
-                            </p>
-                        </div>
-                    </div>
-                </div>
-            {% endfor %}
-        </div>
+        <table class="table table-hover align-middle">
+            <thead class="table-light">
+                <tr>
+                    <th>
+                        {% trans "Name" %}
+                    </th>
+                    <th>
+                        {% trans "Description" %}
+                    </th>
+                    <th>
+                        {% trans "Open" %}
+                    </th>
+                    <th>
+                        {% trans "Members" %}
+                    </th>
+                    <th>
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for team in teams %}
+                    <tr>
+                        <td>
+                            <a href="{% url 'team_detail' team.id %}">{{ team.short_name }}</a>
+                        </td>
+                        <td>
+                            {{ team.description|truncatechars:60 }}
+                        </td>
+                        <td>
+                            {% if team.open_to_new_members %}
+                                <span class="badge bg-success">{% trans "Open" %}</span>
+                            {% else %}
+                                <span class="badge bg-secondary">{% trans "Closed" %}</span>
+                            {% endif %}
+                        </td>
+                        <td>
+                            <span class="badge bg-primary rounded-pill" title="Approved">{{ team.approved_members.count }}</span>
+                            <span class="badge bg-warning rounded-pill" title="Pending">{{ team.pending_members.count }}</span>
+                            <span class="badge bg-warning rounded-pill" title="Waitlisted">{{ team.waitlisted_members.count }}</span>
+                        </td>
+                        <td>
+                            <a href="{% url 'team_edit' team.id %}"
+                               class="btn btn-sm btn-outline-primary"
+                               title="Edit"
+                               aria-label="Edit"><i class="fa-solid fa-pencil"></i></a>
+                            <a href="{% url 'team_delete' team.id %}"
+                               class="btn btn-sm btn-outline-danger"
+                               title="Delete"
+                               aria-label="Delete"><i class="fa-solid fa-trash"></i></a>
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
     </div>
 {% endblock content %}

--- a/tests/portal/test_views.py
+++ b/tests/portal/test_views.py
@@ -47,6 +47,14 @@ class TestPortalIndex:
         assert "Sign out" not in response.content.decode()
         assert "Login" not in response.content.decode()
 
+    def test_manage_teams_card_shown_to_superuser(self, client, admin_user, conference):
+        PortalProfile.objects.create(user=admin_user)
+        client.force_login(admin_user)
+        response = client.get(reverse("index"))
+        assert response.status_code == 200
+        assert "Manage Teams" in response.content.decode()
+        assert reverse("teams") in response.content.decode()
+
 
 @pytest.mark.django_db
 class TestPortalStats:

--- a/tests/volunteer/test_views.py
+++ b/tests/volunteer/test_views.py
@@ -1230,6 +1230,14 @@ class TestTeamList:
         )
         assert active_team in teams
 
+    def test_list_shows_edit_action(self, client, admin_user, conference):
+        team = Team.objects.create(
+            short_name="Comms", description="d", conference=conference
+        )
+        client.force_login(admin_user)
+        response = client.get(reverse("teams"))
+        assert reverse("team_edit", kwargs={"pk": team.pk}) in response.content.decode()
+
 
 @pytest.mark.django_db
 class TestTeamCRUD:


### PR DESCRIPTION
Consistency cleanup from review feedback.

## What changed
- **Teams list → table**: it was the only management list rendered as **cards**; volunteers / sponsorships / conferences are all tables. Now it's a table with Name / Description / Open / Members columns and the same **icon-only edit/delete** actions as the other lists (year switcher + New Team button retained).
- **Dashboard**: added the missing **"Manage Teams"** card to the superuser section (next to Manage Volunteers).

## Tests
- Dashboard shows the Manage Teams card/link; teams list table exposes the edit action.
- **465 pass, 100% coverage**; black/isort/flake8/djlint clean; no schema change.

## Follow-up
- Sponsorship Tier CRUD (separate PR) — the remaining gap.

Refs #321