### PR TITLE
Show team-lead options by full name in the team form

### DIFF
--- a/tests/volunteer/test_forms.py
+++ b/tests/volunteer/test_forms.py
@@ -1,9 +1,26 @@
 import pytest
+from django.contrib.auth.models import User
 
 from portal.models import Conference
 from volunteer.constants import Region
-from volunteer.forms import SelectMultipleWidget, VolunteerProfileForm
+from volunteer.forms import SelectMultipleWidget, TeamForm, VolunteerProfileForm
 from volunteer.models import Language, Team, VolunteerProfile
+
+
+@pytest.mark.django_db
+class TestTeamFormLeadLabels:
+    def test_lead_options_use_full_name_with_username_fallback(self, conference):
+        named = User.objects.create_user("jdoe", first_name="Jane", last_name="Doe")
+        nameless = User.objects.create_user("anon")
+        with_name = VolunteerProfile.objects.create(user=named, conference=conference)
+        without_name = VolunteerProfile.objects.create(
+            user=nameless, conference=conference
+        )
+
+        field = TeamForm(conference=conference).fields["team_leads"]
+
+        assert field.label_from_instance(with_name) == "Jane Doe (jdoe)"
+        assert field.label_from_instance(without_name) == "anon"
 
 
 @pytest.mark.django_db

--- a/volunteer/forms.py
+++ b/volunteer/forms.py
@@ -323,19 +323,31 @@ class VolunteerProfileReviewForm(ModelForm):
         return volunteer_profile
 
 
+class TeamLeadChoiceField(forms.ModelMultipleChoiceField):
+    """Label team-lead options by full name, falling back to username."""
+
+    def label_from_instance(self, obj):
+        name = obj.user.get_full_name()
+        return f"{name} ({obj.user.username})" if name else obj.user.username
+
+
 class TeamForm(ModelForm):
     """Create/edit a team through the portal (instead of Django admin)."""
+
+    team_leads = TeamLeadChoiceField(
+        queryset=VolunteerProfile.objects.none(),
+        widget=forms.CheckboxSelectMultiple,
+        required=False,
+    )
 
     class Meta:
         model = Team
         fields = ["short_name", "description", "open_to_new_members", "team_leads"]
-        widgets = {"team_leads": forms.CheckboxSelectMultiple}
 
     def __init__(self, *args, conference=None, **kwargs):
         super().__init__(*args, **kwargs)
         # Team leads must be volunteers of the team's own edition. The views
         # always pass the edition (active on create, the instance's on edit).
-        self.fields["team_leads"].required = False
         self.fields["team_leads"].queryset = VolunteerProfile.objects.filter(
             conference=conference
-        )
+        ).select_related("user")


### PR DESCRIPTION
The team-leads multi-select on the team create/edit form listed bare **usernames**, making leads hard to identify.

## What changed
- New **`TeamLeadChoiceField`** labels each option as **`Full Name (username)`**, falling back to just the username when no name is set.
- The leads list stays scoped to the team's own edition (now with `select_related("user")`).

## On the other options considered
- **Linking each option to a profile**: not feasible inside a checkbox/select widget (option labels are plain text). The **team detail page already links** each lead to their volunteer profile, which is the right place for that.
- **Restricting to approved volunteers only**: left as-is (all of the edition's volunteers are still selectable) — happy to scope it down if you'd prefer.

## Tests
- Lead labels render as "Jane Doe (jdoe)" and fall back to "anon" when no name.
- **478 pass, 100% coverage**; lint clean.

Refs #321