### PR TITLE
Reorganize landing page and navigation (capability flags)

### DIFF
--- a/portal/context_processors.py
+++ b/portal/context_processors.py
@@ -1,6 +1,48 @@
+from volunteer.models import VolunteerProfile
+
 from .models import Conference
 
 
 def active_conference(request):
     """Expose the active conference to all templates as ``active_conference``."""
     return {"active_conference": Conference.get_active()}
+
+
+def user_capabilities(request):
+    """Expose permission flags to every template so the nav is consistent.
+
+    The nav lives in ``portal/base.html`` and therefore renders on every page,
+    but ``volunteer_profile`` is only set by the handful of views that bother
+    to. Without this processor the sponsorship nav check silently collapses to
+    superuser-only everywhere else. Computing the flags here fixes that and
+    gives every template one vocabulary:
+
+    * ``is_organizer``          — superuser or staff (matches AdminRequiredMixin)
+    * ``can_manage_sponsorship``— same as organizer (create/edit/tiers/invoice)
+    * ``can_view_sponsorship``  — organizer OR an approved volunteer (read-only)
+    * ``active_volunteer_profile`` — this user's profile for the active edition
+    * ``leads_any_team``        — true if they lead at least one team
+    """
+    user = getattr(request, "user", None)
+    if user is None or not user.is_authenticated:
+        return {
+            "is_organizer": False,
+            "can_manage_sponsorship": False,
+            "can_view_sponsorship": False,
+            "active_volunteer_profile": None,
+            "leads_any_team": False,
+        }
+
+    is_organizer = user.is_superuser or user.is_staff
+    profile = VolunteerProfile.objects.filter(
+        user=user, conference=Conference.get_active()
+    ).first()
+    is_approved = bool(profile and profile.is_approved)
+
+    return {
+        "is_organizer": is_organizer,
+        "can_manage_sponsorship": is_organizer,
+        "can_view_sponsorship": is_organizer or is_approved,
+        "active_volunteer_profile": profile,
+        "leads_any_team": bool(profile and profile.team_leads.exists()),
+    }

--- a/portal/settings.py
+++ b/portal/settings.py
@@ -114,6 +114,7 @@ TEMPLATES = [
                 "django.contrib.messages.context_processors.messages",
                 "django.template.context_processors.request",
                 "portal.context_processors.active_conference",
+                "portal.context_processors.user_capabilities",
             ],
         },
     },

--- a/templates/portal/base.html
+++ b/templates/portal/base.html
@@ -42,7 +42,7 @@
         {% block body %}
         {% endblock body %}
         <nav class="navbar navbar-expand-md navbar-dark bg-dark"
-             aria-label="Fourth navbar example">
+             aria-label="Main navigation">
             <div class="container-fluid">
                 <a class="navbar-brand" href="{% url "index" %}">PyLadiesCon Portal</a>
                 {% if active_conference %}
@@ -60,31 +60,87 @@
                 <div class="collapse navbar-collapse" id="navbarsExample04">
                     <ul class="navbar-nav me-auto mb-2 mb-md-0">
                         <li class="nav-item">
-                            <a class="nav-link active" aria-current="page" href="{% url "index" %}">Home</a>
+                            <a class="nav-link active" aria-current="page" href="{% url "index" %}">{% trans "Home" %}</a>
                         </li>
                         {% if user.is_authenticated %}
                             <li class="nav-item">
-                                <a class="nav-link" href="{% url 'volunteer:index' %}">Volunteer</a>
+                                <a class="nav-link" href="{% url 'volunteer:index' %}">{% trans "Volunteer" %}</a>
                             </li>
                         {% endif %}
-                        {% if user.is_superuser %}
+                        {# Sponsorship: a dropdown of actions for managers, a plain #}
+                        {# link for read-only viewers, nothing for everyone else. #}
+                        {% if can_manage_sponsorship %}
+                            <li class="nav-item dropdown">
+                                <a class="nav-link dropdown-toggle"
+                                   href="#"
+                                   id="navSponsorship"
+                                   role="button"
+                                   data-bs-toggle="dropdown"
+                                   aria-expanded="false">{% trans "Sponsorship" %}</a>
+                                <ul class="dropdown-menu" aria-labelledby="navSponsorship">
+                                    <li>
+                                        <a class="dropdown-item" href="{% url 'sponsorship:sponsorship_list' %}">{% trans "All sponsors" %}</a>
+                                    </li>
+                                    <li>
+                                        <a class="dropdown-item"
+                                           href="{% url 'sponsorship:sponsorship_profile_new' %}">{% trans "Add sponsor" %}</a>
+                                    </li>
+                                    <li>
+                                        <a class="dropdown-item" href="{% url 'sponsorship:tier_list' %}">{% trans "Manage tiers" %}</a>
+                                    </li>
+                                </ul>
+                            </li>
+                        {% elif can_view_sponsorship %}
                             <li class="nav-item">
-                                <a class="nav-link" href="{% url 'teams' %}">Teams</a>
+                                <a class="nav-link" href="{% url 'sponsorship:sponsorship_list' %}">{% trans "Sponsorship" %}</a>
                             </li>
                         {% endif %}
-                        {% if user.is_superuser or user.is_authenticated and volunteer_profile and volunteer_profile.is_approved %}
-                            <li class="nav-item">
-                                <a class="nav-link" href="{% url 'sponsorship:sponsorship_list' %}">Sponsorship</a>
+                        {% if is_organizer %}
+                            <li class="nav-item dropdown">
+                                <a class="nav-link dropdown-toggle"
+                                   href="#"
+                                   id="navOrganize"
+                                   role="button"
+                                   data-bs-toggle="dropdown"
+                                   aria-expanded="false">{% trans "Organize" %}</a>
+                                <ul class="dropdown-menu" aria-labelledby="navOrganize">
+                                    <li>
+                                        <a class="dropdown-item" href="{% url 'volunteer:volunteers_list' %}">{% trans "Volunteers" %}</a>
+                                    </li>
+                                    <li>
+                                        <a class="dropdown-item" href="{% url 'teams' %}">{% trans "Teams" %}</a>
+                                    </li>
+                                    <li>
+                                        <a class="dropdown-item" href="{% url 'conference_list' %}">{% trans "Conferences" %}</a>
+                                    </li>
+                                    <li>
+                                        <hr class="dropdown-divider">
+                                    </li>
+                                    <li>
+                                        <a class="dropdown-item" href="{% url 'admin:index' %}">{% trans "Admin area" %}</a>
+                                    </li>
+                                </ul>
                             </li>
                         {% endif %}
-                        <li class="nav-item">
-                            <a class="nav-link" href="{% url 'chapters' %}">PyLadies Chapters</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="https://pyladiescon-portal-docs.netlify.app/">Documentation</a>
-                        </li>
-                        <li class="nav-item">
-                            <a class="nav-link" href="{% url 'portal_stats' %}">Stats</a>
+                        <li class="nav-item dropdown">
+                            <a class="nav-link dropdown-toggle"
+                               href="#"
+                               id="navCommunity"
+                               role="button"
+                               data-bs-toggle="dropdown"
+                               aria-expanded="false">{% trans "Community" %}</a>
+                            <ul class="dropdown-menu" aria-labelledby="navCommunity">
+                                <li>
+                                    <a class="dropdown-item" href="{% url 'chapters' %}">{% trans "PyLadies chapters" %}</a>
+                                </li>
+                                <li>
+                                    <a class="dropdown-item" href="{% url 'portal_stats' %}">{% trans "Stats" %}</a>
+                                </li>
+                                <li>
+                                    <a class="dropdown-item"
+                                       href="https://pyladiescon-portal-docs.netlify.app/">{% trans "Documentation" %}</a>
+                                </li>
+                            </ul>
                         </li>
                         <li class="nav-item">
                             <form action="{% url 'set_language' %}" method="post">
@@ -96,7 +152,7 @@
                                     {% get_language_info_list for LANGUAGES as languages %}
                                     {% for language in languages %}
                                         <option value="{{ language.code }}"
-                                                {% if language.code == LANGUAGE_CODE %} selected{% endif %}>
+                                                {% if language.code == LANGUAGE_CODE %}selected{% endif %}>
                                             {{ language.name_local }} ({{ language.code }})
                                         </option>
                                     {% endfor %}
@@ -110,89 +166,57 @@
                             <a href="#"
                                class="nav-link d-block link-body-emphasis text-decoration-none dropdown-toggle"
                                data-bs-toggle="dropdown"
-                               aria-expanded="true">
-                                {% trans "Welcome, " %}{{ user.username }}
-                                {# djlint:off #}
-{#                                <img src="https://github.com/mdo.png" alt="mdo" width="32" height="32" class="rounded-circle">#}
-                                {# djlint:on #}
-                            </a>
-                            {# djlint:off #}
-                            <ul class="dropdown-menu text-small"
-                                style="position: absolute;
-                                       inset: 0px 0px auto auto;
-                                       margin: 0px;
-                                       transform: translate(0px, 34px)"
-                                data-popper-placement="bottom-end">
-                            {# djlint:on #}
-                            {% if user.is_superuser %}
+                               aria-expanded="false">{% trans "Welcome, " %}{{ user.username }}</a>
+                            <ul class="dropdown-menu dropdown-menu-end text-small">
+                                {% if is_organizer %}
+                                    <li>
+                                        <a class="dropdown-item" href="{% url 'admin:index' %}">{% trans "Admin Area" %}</a>
+                                    </li>
+                                    <li>
+                                        <hr class="dropdown-divider">
+                                    </li>
+                                {% endif %}
                                 <li>
-                                    <a class="dropdown-item" href="{% url 'admin:index' %}">{% trans "Admin Area" %}</a>
+                                    <a class="dropdown-item" href="{% url 'portal_account:index' %}">{% trans "Manage account" %}</a>
                                 </li>
-                                <li>
-                                    <hr class="dropdown-divider">
-                                </li>
-                            {% endif %}
-                            <li>
-                                <a class="dropdown-item" href="{% url 'portal_account:index' %}">{% trans "Manage Profile" %}</a>
-                            </li>
-                            {% url 'account_email' as email_url_ %}
-                            {% if email_url_ %}
-                                <li>
-                                    <a class="dropdown-item" href="{{ email_url_ }}">{% trans "Manage Emails" %}</a>
-                                </li>
-                            {% endif %}
-                            {% url 'account_change_password' as change_password_url_ %}
-                            {% if change_password_url_ %}
-                                <li>
-                                    <a class="dropdown-item" href="{{ change_password_url_ }}">{% trans "Change Password" %}</a>
-                                </li>
-                            {% endif %}
-                            <li>
-                                <hr class="dropdown-divider">
-                            </li>
-                            {% url 'account_logout' as logout_url_ %}
-                            {% if logout_url_ %}
-                                <li>
-                                    <a class="dropdown-item" href="{{ logout_url_ }}">{% trans "Sign Out" %}</a>
-                                </li>
-                            {% endif %}
-                        </ul>
-                    </div>
-                {% else %}
-                    <div>
-                        <a type="button"
-                           class="btn btn-outline-light"
-                           href="{% url 'account_login' %}">Login</a>
-                    </div>
-                {% endif %}
-                {# djlint:off #}
-{#                    <form role="search">#}
-{#                        <input class="form-control" type="search" placeholder="Search" aria-label="Search">#}
-{#                    </form>#}
-                {# djlint:on #}
+                                {% url 'account_logout' as logout_url_ %}
+                                {% if logout_url_ %}
+                                    <li>
+                                        <a class="dropdown-item" href="{{ logout_url_ }}">{% trans "Sign Out" %}</a>
+                                    </li>
+                                {% endif %}
+                            </ul>
+                        </div>
+                    {% else %}
+                        <div>
+                            <a type="button"
+                               class="btn btn-outline-light"
+                               href="{% url 'account_login' %}">Login</a>
+                        </div>
+                    {% endif %}
+                </div>
             </div>
+        </nav>
+        <div class="container my-5">
+            {% block content %}
+            {% endblock content %}
         </div>
-    </nav>
-    <div class="container my-5">
-        {% block content %}
-        {% endblock content %}
-    </div>
-    <footer class="footer mt-auto py-3 bg-dark text-white">
-        <div class="container d-flex align-items-center justify-content-between">
-            <span>
-                Problems with this site? File an issue in our
-                <a href="https://github.com/pyladies/pyladiescon-portal">GitHub repository</a>, or open a pull request.
-            </span>
-            {% block footer_text %}
-            {% endblock footer_text %}
-            <a href="https://www.djangoproject.com/">
-                <img src="https://www.djangoproject.com/m/img/badges/djangopowered126x54.gif"
-                     alt="Powered by Django."
-                     title="Powered by Django."
-                     width="126"
-                     height="54" />
-            </a>
-        </div>
-    </footer>
-</body>
+        <footer class="footer mt-auto py-3 bg-dark text-white">
+            <div class="container d-flex align-items-center justify-content-between">
+                <span>
+                    Problems with this site? File an issue in our
+                    <a href="https://github.com/pyladies/pyladiescon-portal">GitHub repository</a>, or open a pull request.
+                </span>
+                {% block footer_text %}
+                {% endblock footer_text %}
+                <a href="https://www.djangoproject.com/">
+                    <img src="https://www.djangoproject.com/m/img/badges/djangopowered126x54.gif"
+                         alt="Powered by Django."
+                         title="Powered by Django."
+                         width="126"
+                         height="54" />
+                </a>
+            </div>
+        </footer>
+    </body>
 </html>

--- a/templates/portal/index.html
+++ b/templates/portal/index.html
@@ -10,223 +10,221 @@
         </h2>
         {% if user.is_authenticated %}
             <div class="row g-4 py-5 row-cols-1 row-cols-lg-3">
+                {# ---- My volunteering (everyone) ---- #}
                 <div class="feature col">
                     <div class="d-inline-flex align-items-center justify-content-center fa-3x mb-3">
                         <i class="fa-solid fa-user-group"></i>
                     </div>
                     <h3 class="fs-2 text-body-emphasis">
-                        {% trans "Volunteer" %}
+                        {% trans "My volunteering" %}
                     </h3>
                     <p>
-                        {% if user.is_authenticated and volunteer_profile %}
-                            {% translate "Thanks for signing up to volunteer. Check back here to manage your volunteer profile and your availabilities. You can always update your profile in case there has been changes to your situation and/or availabilities." %}
+                        {% if volunteer_profile %}
+                            {% translate "Manage your volunteer profile and availability, and see the editions you've signed up for." %}
                         {% else %}
-                            {% translate "Sign up to volunteer with us! Fill in your Volunteer profile and we'll get you set up." %}
+                            {% translate "Sign up to volunteer with us! Fill in your volunteer profile and we'll get you set up." %}
                         {% endif %}
                     </p>
                     <ul class="list-unstyled ps-8">
-                        {% if user.is_authenticated and volunteer_profile %}
+                        {% if volunteer_profile %}
                             <li>
                                 <a href="{% url 'volunteer:index' %}" class="icon-link">
-                                    {% translate "Manage your volunteer profile" %}
+                                    {% translate "Manage my profile" %}
+                                    <i class="fa-solid fa-chevron-right"></i>
+                                </a>
+                            </li>
+                            <li>
+                                <a href="{% url 'volunteer:my_conferences' %}" class="icon-link">
+                                    {% translate "My conferences" %}
                                     <i class="fa-solid fa-chevron-right"></i>
                                 </a>
                             </li>
                         {% else %}
                             <li>
                                 <a href="{% url 'volunteer:volunteer_profile_new' %}" class="icon-link">
-                                    {% translate "Volunteer Now" %}
+                                    {% translate "Volunteer now" %}
                                     <i class="fa-solid fa-chevron-right"></i>
                                 </a>
                             </li>
                         {% endif %}
-                        <li>
-                            <a href="https://conference.pyladies.com/docs/" class="icon-link">
-                                {% translate "Team Descriptions" %}
-                                <i class="fa-solid fa-chevron-right"></i>
-                            </a>
-                        </li>
-                        <li>
-                            <a href="https://conference.pyladies.com/docs/roles_and_responsibilities/"
-                               class="icon-link">
-                                {% translate "Volunteer Responsibilities" %}
-                                <i class="fa-solid fa-chevron-right"></i>
-                            </a>
-                        </li>
-                        <li>
-                            <a href="https://discord.com/invite/2fUN4ddVfP" class="icon-link">
-                                {% translate "Join our Discord" %}
-                                <i class="fa-brands fa-discord"></i>
-                            </a>
-                        </li>
                     </ul>
                 </div>
-                <div class="feature col">
-                    <div class="d-inline-flex align-items-center justify-content-center fa-3x mb-3">
-                        <i class="fa-solid fa-hand-holding-dollar"></i>
-                    </div>
-                    <h3 class="fs-2 text-body-emphasis">
-                        {% trans "Sponsorship" %}
-                    </h3>
-                    <p>
-                        {% trans "Resources for sponsorships." %}
-                    </p>
-                    <ul class="list-unstyled ps-8">
-                        <li>
-                            <a href="https://2025.conference.pyladies.com/en/sponsors/"
-                               class="icon-link">Sponsorship Packages <i class="fa-solid fa-chevron-right"></i></a>
-                        </li>
-                        {% if user.is_authenticated and volunteer_profile and volunteer_profile.is_approved %}
-                            <li>
-                                <a href="{% url 'sponsorship:sponsorship_list' %}" class="icon-link">View Current Sponsorships <i class="fa-solid fa-chevron-right"></i></a>
-                            </li>
-                        {% endif %}
-                    </ul>
-                </div>
-                <div class="feature col">
-                    <div class="d-inline-flex align-items-center justify-content-center fa-3x mb-3">
-                        <i class="fa-solid fa-microphone"></i>
-                    </div>
-                    <h3 class="fs-2 text-body-emphasis">
-                        {% trans "Speaker Portal" %}
-                    </h3>
-                    <p>
-                        {% trans "Resources for speakers and presenters." %}
-                    </p>
-                    <ul class="list-unstyled ps-8">
-                        <li>
-                            <a href="https://conference.pyladies.com/docs/speakers/speaker_guide/"
-                               class="icon-link">Speaker Guide <i class="fa-solid fa-chevron-right"></i></a>
-                        </li>
-                        <li>
-                            <a href="https://conference.pyladies.com/docs/speakers/keynote_speaker_guide/"
-                               class="icon-link">Keynote Speaker Guide <i class="fa-solid fa-chevron-right"></i></a>
-                        </li>
-                    </ul>
-                </div>
-                {% if user.is_superuser %}
+                {# ---- Sponsorship (one adaptive card) ---- #}
+                {% if can_view_sponsorship %}
                     <div class="feature col">
                         <div class="d-inline-flex align-items-center justify-content-center fa-3x mb-3">
-                            <i class="fa-solid fa-people-roof"></i>
+                            <i class="fa-solid fa-hand-holding-dollar"></i>
                         </div>
                         <h3 class="fs-2 text-body-emphasis">
-                            Manage Volunteers
+                            {% trans "Sponsorship" %}
+                            {% if can_manage_sponsorship %}
+                                <span class="badge text-bg-success align-middle fs-6">{% trans "Manage" %}</span>
+                            {% else %}
+                                <span class="badge text-bg-secondary align-middle fs-6">{% trans "Read-only" %}</span>
+                            {% endif %}
                         </h3>
                         <p>
-                            Review volunteer applications and manage team members.
+                            {% if can_manage_sponsorship %}
+                                {% trans "The full sponsor pipeline, tiers, and invoicing." %}
+                            {% else %}
+                                {% trans "Browse this year's confirmed sponsors and packages." %}
+                            {% endif %}
+                        </p>
+                        <ul class="list-unstyled ps-8">
+                            <li>
+                                <a href="{% url 'sponsorship:sponsorship_list' %}" class="icon-link">
+                                    {% if can_manage_sponsorship %}
+                                        {% trans "All sponsors" %}
+                                    {% else %}
+                                        {% trans "View sponsors" %}
+                                    {% endif %}
+                                    <i class="fa-solid fa-chevron-right"></i>
+                                </a>
+                            </li>
+                            {% if can_manage_sponsorship %}
+                                <li>
+                                    <a href="{% url 'sponsorship:sponsorship_profile_new' %}"
+                                       class="icon-link">
+                                        {% trans "Add sponsor" %}
+                                        <i class="fa-solid fa-chevron-right"></i>
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="{% url 'sponsorship:tier_list' %}" class="icon-link">
+                                        {% trans "Manage tiers" %}
+                                        <i class="fa-solid fa-chevron-right"></i>
+                                    </a>
+                                </li>
+                            {% endif %}
+                            <li>
+                                <a href="https://2025.conference.pyladies.com/en/sponsors/"
+                                   class="icon-link">
+                                    {% trans "Sponsorship packages" %}
+                                    <i class="fa-solid fa-arrow-up-right-from-square"></i>
+                                </a>
+                            </li>
+                        </ul>
+                    </div>
+                {% endif %}
+                {# ---- Organizer tools (admin/staff) ---- #}
+                {% if is_organizer %}
+                    <div class="feature col">
+                        <div class="d-inline-flex align-items-center justify-content-center fa-3x mb-3">
+                            <i class="fa-solid fa-screwdriver-wrench"></i>
+                        </div>
+                        <h3 class="fs-2 text-body-emphasis">
+                            {% trans "Organizer tools" %}
+                        </h3>
+                        <p>
+                            {% trans "Review volunteers, manage teams, and run conference editions." %}
                         </p>
                         <ul class="list-unstyled ps-8">
                             <li>
                                 <a href="{% url 'volunteer:volunteers_list' %}" class="icon-link">
-                                    {% translate "Manage Volunteers" %}
+                                    {% trans "Volunteers" %}
                                     <i class="fa-solid fa-chevron-right"></i>
                                 </a>
                             </li>
-                        </ul>
-                    </div>
-                    <div class="feature col">
-                        <div class="d-inline-flex align-items-center justify-content-center fa-3x mb-3">
-                            <i class="fa-solid fa-people-group"></i>
-                        </div>
-                        <h3 class="fs-2 text-body-emphasis">
-                            Manage Teams
-                        </h3>
-                        <p>
-                            Create and manage the conference teams and their leads.
-                        </p>
-                        <ul class="list-unstyled ps-8">
                             <li>
                                 <a href="{% url 'teams' %}" class="icon-link">
-                                    {% translate "Manage Teams" %}
+                                    {% trans "Teams" %}
                                     <i class="fa-solid fa-chevron-right"></i>
                                 </a>
                             </li>
-                        </ul>
-                    </div>
-                    <div class="feature col">
-                        <div class="d-inline-flex align-items-center justify-content-center fa-3x mb-3">
-                            <i class="fa-solid fa-money-bill-trend-up"></i>
-                        </div>
-                        <h3 class="fs-2 text-body-emphasis">
-                            Manage Sponsorships
-                        </h3>
-                        <p>
-                            Review and Track Sponsorship progress.
-                        </p>
-                        <ul class="list-unstyled ps-8">
-                            <li>
-                                <a href="{% url 'sponsorship:sponsorship_list' %}" class="icon-link">Manage Sponsorships <i class="fa-solid fa-chevron-right"></i></a>
-                            </li>
-                            <li>
-                                <a href="{% url 'sponsorship:sponsorship_profile_new' %}"
-                                   class="icon-link">New Sponsorship <i class="fa-solid fa-chevron-right"></i></a>
-                            </li>
-                            <li>
-                                <a href="{% url 'sponsorship:tier_list' %}" class="icon-link">Manage Sponsorship Tiers <i class="fa-solid fa-chevron-right"></i></a>
-                            </li>
-                        </ul>
-                    </div>
-                    <div class="feature col">
-                        <div class="d-inline-flex align-items-center justify-content-center fa-3x mb-3">
-                            <i class="fa-solid fa-user-secret"></i>
-                        </div>
-                        <h3 class="fs-2 text-body-emphasis">
-                            Admin Area
-                        </h3>
-                        <p>
-                            Access the Django Admin area for your superuser privileges. Use your power responsibly!
-                        </p>
-                        <ul class="list-unstyled ps-8">
-                            <li>
-                                <a href="{% url 'admin:index' %}" class="icon-link">
-                                    {% translate "Admin Area" %}
-                                    <i class="fa-solid fa-chevron-right"></i>
-                                </a>
-                            </li>
-                        </ul>
-                    </div>
-                    <div class="feature col">
-                        <div class="d-inline-flex align-items-center justify-content-center fa-3x mb-3">
-                            <i class="fa-solid fa-calendar-days"></i>
-                        </div>
-                        <h3 class="fs-2 text-body-emphasis">
-                            Manage Conferences
-                        </h3>
-                        <p>
-                            View, edit, and manage all conference editions.
-                        </p>
-                        <ul class="list-unstyled ps-8">
                             <li>
                                 <a href="{% url 'conference_list' %}" class="icon-link">
-                                    {% translate "Manage Conferences" %}
+                                    {% trans "Conferences" %}
+                                    <i class="fa-solid fa-chevron-right"></i>
+                                </a>
+                            </li>
+                            {% if can_start_next_year %}
+                                <li>
+                                    <a href="{% url 'start_new_year' %}" class="icon-link">
+                                        {% trans "Start next year" %}
+                                        <i class="fa-solid fa-chevron-right"></i>
+                                    </a>
+                                </li>
+                            {% endif %}
+                            <li>
+                                <a href="{% url 'admin:index' %}" class="icon-link">
+                                    {% trans "Admin area" %}
                                     <i class="fa-solid fa-chevron-right"></i>
                                 </a>
                             </li>
                         </ul>
                     </div>
-                    {% if can_start_next_year %}
-                        <div class="feature col">
-                            <div class="d-inline-flex align-items-center justify-content-center fa-3x mb-3">
-                                <i class="fa-solid fa-calendar-plus"></i>
-                            </div>
-                            <h3 class="fs-2 text-body-emphasis">
-                                Start Next Year
-                            </h3>
-                            <p>
-                                Stand up the next conference edition and carry teams,
-                                tiers, goals, and returning volunteers over from this year.
-                            </p>
-                            <ul class="list-unstyled ps-8">
+                {% endif %}
+            </div>
+            {# ---- Resources, grouped by role (external reference) ---- #}
+            <div class="row pb-5">
+                <div class="col">
+                    <h3 class="fs-4 text-body-emphasis pb-2 border-bottom">
+                        {% trans "Resources" %}
+                    </h3>
+                    <div class="row row-cols-1 row-cols-md-3 g-4 pt-3">
+                        <div class="col">
+                            <h4 class="fs-6 text-uppercase text-secondary">
+                                {% trans "Volunteering" %}
+                            </h4>
+                            <ul class="list-unstyled">
                                 <li>
-                                    <a href="{% url 'start_new_year' %}" class="icon-link">
-                                        {% translate "Start Next Year's Conference" %}
-                                        <i class="fa-solid fa-chevron-right"></i>
+                                    <a href="https://conference.pyladies.com/docs/" class="icon-link">
+                                        {% trans "Team descriptions" %}
+                                        <i class="fa-solid fa-arrow-up-right-from-square"></i>
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="https://conference.pyladies.com/docs/roles_and_responsibilities/"
+                                       class="icon-link">
+                                        {% trans "Responsibilities" %}
+                                        <i class="fa-solid fa-arrow-up-right-from-square"></i>
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="https://discord.com/invite/2fUN4ddVfP" class="icon-link">
+                                        {% trans "Join our Discord" %}
+                                        <i class="fa-brands fa-discord"></i>
                                     </a>
                                 </li>
                             </ul>
                         </div>
-                    {% endif %}
-                {% endif %}
+                        <div class="col">
+                            <h4 class="fs-6 text-uppercase text-secondary">
+                                {% trans "Speaking" %}
+                            </h4>
+                            <ul class="list-unstyled">
+                                <li>
+                                    <a href="https://conference.pyladies.com/docs/speakers/speaker_guide/"
+                                       class="icon-link">
+                                        {% trans "Speaker guide" %}
+                                        <i class="fa-solid fa-arrow-up-right-from-square"></i>
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="https://conference.pyladies.com/docs/speakers/keynote_speaker_guide/"
+                                       class="icon-link">
+                                        {% trans "Keynote speaker guide" %}
+                                        <i class="fa-solid fa-arrow-up-right-from-square"></i>
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
+                        <div class="col">
+                            <h4 class="fs-6 text-uppercase text-secondary">
+                                {% trans "Sponsorship and finance" %}
+                            </h4>
+                            <ul class="list-unstyled">
+                                <li>
+                                    <a href="https://2025.conference.pyladies.com/en/sponsors/"
+                                       class="icon-link">
+                                        {% trans "Sponsorship prospectus" %}
+                                        <i class="fa-solid fa-arrow-up-right-from-square"></i>
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
             </div>
         {% else %}
             <div class="row row-cols-1 row-cols-md-2 align-items-md-center g-5 py-5">

--- a/tests/portal/test_context_processors.py
+++ b/tests/portal/test_context_processors.py
@@ -1,0 +1,70 @@
+import pytest
+from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory
+
+from portal.context_processors import user_capabilities
+from volunteer.models import ApplicationStatus, Team, VolunteerProfile
+
+
+def _request(user=None):
+    request = RequestFactory().get("/")
+    if user is not None:
+        request.user = user
+    return request
+
+
+@pytest.mark.django_db
+class TestUserCapabilities:
+    def test_request_without_user(self):
+        # A request that never went through auth middleware has no ``user``.
+        caps = user_capabilities(_request())
+        assert caps["is_organizer"] is False
+        assert caps["can_manage_sponsorship"] is False
+        assert caps["can_view_sponsorship"] is False
+        assert caps["active_volunteer_profile"] is None
+        assert caps["leads_any_team"] is False
+
+    def test_anonymous_user(self):
+        caps = user_capabilities(_request(AnonymousUser()))
+        assert caps["is_organizer"] is False
+        assert caps["can_view_sponsorship"] is False
+
+    def test_organizer(self, admin_user, conference):
+        caps = user_capabilities(_request(admin_user))
+        assert caps["is_organizer"] is True
+        assert caps["can_manage_sponsorship"] is True
+        assert caps["can_view_sponsorship"] is True
+
+    def test_approved_volunteer_is_read_only_viewer(self, portal_user, conference):
+        VolunteerProfile.objects.create(
+            user=portal_user,
+            conference=conference,
+            application_status=ApplicationStatus.APPROVED,
+        )
+        caps = user_capabilities(_request(portal_user))
+        assert caps["is_organizer"] is False
+        assert caps["can_manage_sponsorship"] is False
+        assert caps["can_view_sponsorship"] is True
+        assert caps["active_volunteer_profile"] is not None
+
+    def test_unapproved_volunteer_cannot_view(self, portal_user, conference):
+        VolunteerProfile.objects.create(
+            user=portal_user,
+            conference=conference,
+            application_status=ApplicationStatus.PENDING,
+        )
+        caps = user_capabilities(_request(portal_user))
+        assert caps["can_view_sponsorship"] is False
+
+    def test_leads_any_team(self, portal_user, conference):
+        profile = VolunteerProfile.objects.create(
+            user=portal_user,
+            conference=conference,
+            application_status=ApplicationStatus.APPROVED,
+        )
+        team = Team.objects.create(
+            short_name="Comms", description="d", conference=conference
+        )
+        team.team_leads.add(profile)
+        caps = user_capabilities(_request(portal_user))
+        assert caps["leads_any_team"] is True

--- a/tests/portal/test_views.py
+++ b/tests/portal/test_views.py
@@ -47,13 +47,15 @@ class TestPortalIndex:
         assert "Sign out" not in response.content.decode()
         assert "Login" not in response.content.decode()
 
-    def test_manage_teams_card_shown_to_superuser(self, client, admin_user, conference):
+    def test_organizer_tools_shown_to_superuser(self, client, admin_user, conference):
         PortalProfile.objects.create(user=admin_user)
         client.force_login(admin_user)
         response = client.get(reverse("index"))
         assert response.status_code == 200
-        assert "Manage Teams" in response.content.decode()
-        assert reverse("teams") in response.content.decode()
+        content = response.content.decode()
+        assert "Organizer tools" in content
+        assert reverse("teams") in content
+        assert reverse("volunteer:volunteers_list") in content
 
     def test_manage_tiers_link_shown_to_superuser(self, client, admin_user, conference):
         PortalProfile.objects.create(user=admin_user)
@@ -294,7 +296,7 @@ class TestStartNextYearGate:
         PortalProfile.objects.create(user=admin_user)
         client.force_login(admin_user)
         response = client.get(reverse("index"))
-        assert "Start Next Year's Conference" in response.content.decode()
+        assert "Start next year" in response.content.decode()
 
     def test_card_hidden_when_date_not_passed(self, client, admin_user, conference):
         PortalProfile.objects.create(user=admin_user)
@@ -302,7 +304,7 @@ class TestStartNextYearGate:
         conference.save()
         client.force_login(admin_user)
         response = client.get(reverse("index"))
-        assert "Start Next Year's Conference" not in response.content.decode()
+        assert "Start next year" not in response.content.decode()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Slice 2 of the redesign (from the provided spec). Verified against the repo; all `{% url %}` references resolve, tests + lint green.

## The latent bug this fixes
The old nav gated Sponsorship on `volunteer_profile`, which is only in context on the handful of views that set it. On every other page that check silently fell back to **superuser-only**. Moving the flags into a context processor makes the nav correct on **every** page.

## What changed
- **`portal.context_processors.user_capabilities`** exposes to every template:
  `is_organizer`, `can_manage_sponsorship`, `can_view_sponsorship` (organizer OR approved volunteer), `active_volunteer_profile`, `leads_any_team`. Registered in settings after `active_conference`.
- **Nav** (`base.html`): `Home | Volunteer | Sponsorship* | Organize ▾ | Community ▾ | [lang] | Welcome ▾`.
  - Sponsorship: dropdown (All sponsors / Add sponsor / Manage tiers) for managers, plain link for read-only viewers, hidden otherwise.
  - `Organize ▾` (organizers): Volunteers, Teams, Conferences, Admin area.
  - `Community ▾` (everyone): chapters, Stats, Documentation.
  - User menu slimmed to Admin Area / Manage account / Sign Out (email + password live on the account page now). Also drops the old inline-style dropdown `djlint:off` hack and dead commented markup.
- **Landing** (`index.html`): My volunteering · one adaptive Sponsorship card (Manage / Read-only badge) · a single **Organizer tools** card replacing the five separate admin cards · Resources grouped by role. Anonymous marketing landing unchanged.

## Tests
- New `test_context_processors.py`: capability flags across no-user / anonymous / organizer / approved-viewer / unapproved / team-lead.
- Updated two landing tests for the reorg (Organizer tools card; "Start next year" wording).
- **492 pass, 100% coverage**; black/isort/flake8/djlint clean; no schema change.

## Still deferred (per spec)
- `MyTeamsView` + a "My teams" nav entry for leads (the wired-but-unused `leads_any_team` flag is ready for it).
- Hiding dead Edit/Delete actions for read-only sponsorship viewers in `SponsorshipProfileTable.render_actions`.

Refs #321