### PR TITLE
Add a "My teams" page and nav entry for team leads

### DIFF
--- a/portal/urls.py
+++ b/portal/urls.py
@@ -53,6 +53,11 @@ urlpatterns = [
         name="teams",
     ),
     path(
+        "teams/mine/",
+        volunteer_view.MyTeamsView.as_view(),
+        name="my_teams",
+    ),
+    path(
         "teams/new/",
         volunteer_view.TeamCreate.as_view(),
         name="team_new",

--- a/templates/portal/base.html
+++ b/templates/portal/base.html
@@ -67,6 +67,11 @@
                                 <a class="nav-link" href="{% url 'volunteer:index' %}">{% trans "Volunteer" %}</a>
                             </li>
                         {% endif %}
+                        {% if leads_any_team %}
+                            <li class="nav-item">
+                                <a class="nav-link" href="{% url 'my_teams' %}">{% trans "My teams" %}</a>
+                            </li>
+                        {% endif %}
                         {# Sponsorship: a dropdown of actions for managers, a plain #}
                         {# link for read-only viewers, nothing for everyone else. #}
                         {% if can_manage_sponsorship %}

--- a/templates/team/my_teams.html
+++ b/templates/team/my_teams.html
@@ -1,0 +1,47 @@
+{% extends "portal/base.html" %}
+{% load i18n %}
+{% block content %}
+    <div class="container px-4 py-4">
+        <h1 class="display-6 pb-2 border-bottom">
+            {% trans "My teams" %}
+        </h1>
+        {% if teams %}
+            <table class="table table-hover align-middle">
+                <thead class="table-light">
+                    <tr>
+                        <th>
+                            {% trans "Edition" %}
+                        </th>
+                        <th>
+                            {% trans "Name" %}
+                        </th>
+                        <th>
+                            {% trans "Members" %}
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for team in teams %}
+                        <tr>
+                            <td>
+                                {{ team.conference.year }}
+                            </td>
+                            <td>
+                                <a href="{% url 'team_dashboard' team.id %}">{{ team.short_name }}</a>
+                            </td>
+                            <td>
+                                <span class="badge bg-primary rounded-pill">{{ team.approved_members.count }}</span> {% trans "approved" %}
+                                <span class="badge bg-warning rounded-pill">{{ team.pending_members.count }}</span> {% trans "pending" %}
+                                <span class="badge bg-secondary rounded-pill">{{ team.waitlisted_members.count }}</span> {% trans "waitlisted" %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        {% else %}
+            <p class="text-secondary">
+                {% trans "You don't lead any teams yet." %}
+            </p>
+        {% endif %}
+    </div>
+{% endblock content %}

--- a/tests/volunteer/test_views.py
+++ b/tests/volunteer/test_views.py
@@ -1380,3 +1380,55 @@ class TestTeamDashboard:
         client.force_login(portal_user)
         response = client.get(reverse("team_dashboard", kwargs={"pk": 99999}))
         assert response.status_code in (302, 403)
+
+
+@pytest.mark.django_db
+class TestMyTeams:
+    def _lead(self, user, conference):
+        profile = VolunteerProfile.objects.create(
+            user=user,
+            conference=conference,
+            application_status=ApplicationStatus.APPROVED,
+        )
+        team = Team.objects.create(
+            short_name="Led Team", description="d", conference=conference
+        )
+        team.team_leads.add(profile)
+        return team
+
+    def test_requires_login(self, client):
+        response = client.get(reverse("my_teams"))
+        assert response.status_code == 302
+
+    def test_lead_sees_only_their_teams(self, client, portal_user, conference):
+        led = self._lead(portal_user, conference)
+        other = Team.objects.create(
+            short_name="Other Team", description="d", conference=conference
+        )
+        client.force_login(portal_user)
+        response = client.get(reverse("my_teams"))
+        assert response.status_code == 200
+        teams = list(response.context["teams"])
+        assert led in teams
+        assert other not in teams
+
+    def test_non_lead_sees_empty_state(self, client, portal_user, conference):
+        Team.objects.create(
+            short_name="Some Team", description="d", conference=conference
+        )
+        client.force_login(portal_user)
+        response = client.get(reverse("my_teams"))
+        assert response.status_code == 200
+        assert list(response.context["teams"]) == []
+        assert "You don't lead any teams yet." in response.content.decode()
+
+    def test_nav_shows_my_teams_for_lead(self, client, portal_user, conference):
+        self._lead(portal_user, conference)
+        client.force_login(portal_user)
+        response = client.get(reverse("volunteer:index"))
+        assert reverse("my_teams") in response.content.decode()
+
+    def test_nav_hides_my_teams_for_non_lead(self, client, portal_user, conference):
+        client.force_login(portal_user)
+        response = client.get(reverse("volunteer:index"))
+        assert reverse("my_teams") not in response.content.decode()

--- a/volunteer/views.py
+++ b/volunteer/views.py
@@ -2,6 +2,7 @@ import django_filters
 import django_tables2 as tables
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.postgres.search import SearchQuery, SearchVector
 from django.http import Http404
 from django.shortcuts import redirect, render
@@ -419,6 +420,26 @@ class TeamDashboardView(TeamLeadRequiredMixin, DetailView):
             is_admin or team.team_leads.filter(user=user).exists()
         )
         return context
+
+
+class MyTeamsView(LoginRequiredMixin, ListView):
+    """Teams the current user leads, across every edition.
+
+    A one-screen landing for leads: each team links to its dashboard. The "My
+    teams" nav entry (gated on ``leads_any_team``) points here.
+    """
+
+    model = Team
+    template_name = "team/my_teams.html"
+    context_object_name = "teams"
+
+    def get_queryset(self):
+        return (
+            Team.objects.filter(team_leads__user=self.request.user)
+            .select_related("conference")
+            .order_by("-conference__year", "short_name")
+            .distinct()
+        )
 
 
 class TeamCreate(VolunteerAdminRequiredMixin, CreateView):


### PR DESCRIPTION
Slice 3 of the redesign. Uses the `leads_any_team` flag wired in slice 2 (#369).

## What changed
- **`MyTeamsView`** at `teams/mine/` (login required): lists every team the current user leads, across all editions, each linking to its **dashboard**. Shows an empty state when they lead none.
- **Nav**: a **"My teams"** entry appears next to Volunteer, only when `leads_any_team` is true.

## Tests
- Requires login; lead sees only their teams (not others'); non-lead gets the empty state; nav entry shows for leads and is hidden for non-leads.
- **497 pass, 100% coverage**; black/isort/flake8/djlint clean; no schema change.

## Remaining deferred (per spec)
- Hide the dead Edit/Delete actions for read-only sponsorship viewers in `SponsorshipProfileTable.render_actions` — the last item on the redesign deferred list.

Refs #321