### PR TITLE
Hide sponsor edit/delete actions from read-only viewers

### DIFF
--- a/sponsorship/views.py
+++ b/sponsorship/views.py
@@ -292,6 +292,15 @@ class SponsorshipProfileList(CanViewSponsorship, SingleTableMixin, FilterView):
         # yields an empty list rather than leaking another year's sponsors.
         return super().get_queryset().filter(conference=self.get_selected_conference())
 
+    def get_table_kwargs(self):
+        kwargs = super().get_table_kwargs()
+        user = self.request.user
+        # Read-only viewers (approved volunteers, not staff) can't edit or
+        # delete, so drop the actions column instead of showing buttons that 403.
+        if not (user.is_superuser or user.is_staff):
+            kwargs["exclude"] = ("actions",)
+        return kwargs
+
     def get_context_data(self, **kwargs):
         # kwargs.pop('filter')
         context = super().get_context_data(**kwargs)

--- a/tests/sponsorship/test_views.py
+++ b/tests/sponsorship/test_views.py
@@ -872,3 +872,48 @@ class TestSponsorshipTierCRUD:
         # Invalid year falls back to the active edition.
         invalid = list(client.get(f"{url}?conference=99999").context["tiers"])
         assert active_tier in invalid
+
+
+@pytest.mark.django_db
+class TestSponsorActionsColumn:
+    """The actions (edit/delete) column is hidden from read-only viewers."""
+
+    def _profile(self, conference):
+        tier = SponsorshipTier.objects.create(
+            name="Gold", amount=5000, description="g", conference=conference
+        )
+        return SponsorshipProfile.objects.create(
+            organization_name="Corp",
+            sponsorship_tier=tier,
+            progress_status=SponsorshipProgressStatus.APPROVED,
+            conference=conference,
+        )
+
+    def test_actions_hidden_for_read_only_viewer(self, client, portal_user, conference):
+        profile = self._profile(conference)
+        VolunteerProfile.objects.create(
+            user=portal_user,
+            application_status=ApplicationStatus.APPROVED,
+            conference=conference,
+        )
+        client.force_login(portal_user)
+        response = client.get(reverse("sponsorship:sponsorship_list"))
+        assert response.status_code == 200
+        columns = [column.name for column in response.context["table"].columns]
+        assert "actions" not in columns
+        edit_url = reverse(
+            "sponsorship:sponsorship_profile_edit", kwargs={"pk": profile.pk}
+        )
+        assert edit_url not in response.content.decode()
+
+    def test_actions_shown_for_organizer(self, client, admin_user, conference):
+        profile = self._profile(conference)
+        client.force_login(admin_user)
+        response = client.get(reverse("sponsorship:sponsorship_list"))
+        assert response.status_code == 200
+        columns = [column.name for column in response.context["table"].columns]
+        assert "actions" in columns
+        edit_url = reverse(
+            "sponsorship:sponsorship_profile_edit", kwargs={"pk": profile.pk}
+        )
+        assert edit_url in response.content.decode()


### PR DESCRIPTION
The last item on the redesign deferred list.

## Problem
The sponsor list table rendered edit/delete icons for **every** viewer, including approved-volunteer (read-only) viewers — but those actions are admin-only, so clicking them 403s.

## Fix
`SponsorshipProfileList.get_table_kwargs` excludes the `actions` column entirely for non-organizers (anyone who isn't staff/superuser), so read-only viewers see a clean table with no dead buttons. The **detail page already gated** its edit/delete on staff/superuser, so no change needed there.

## Tests
- Read-only viewer: no `actions` column, no edit URL in the page.
- Organizer: `actions` column present, edit URL rendered.
- **499 pass, 100% coverage**; black/isort/flake8/djlint clean; no schema change.

This clears the redesign's deferred list (the `MyTeamsView`, capability flags, and dashboard slices all landed earlier).

Refs #321