### PR TITLE
Rework sub-app landings (volunteer hub, teams dashboard, sponsorship redirect)

### DIFF
--- a/sponsorship/urls.py
+++ b/sponsorship/urls.py
@@ -1,10 +1,18 @@
 from django.urls import path
+from django.views.generic import RedirectView
 
 from . import views
 
 app_name = "sponsorship"
 
 urlpatterns = [
+    # The list (which carries the stats header) is the sponsorship home. Make the
+    # bare /sponsorship/ resolve to it instead of 404-ing.
+    path(
+        "",
+        RedirectView.as_view(pattern_name="sponsorship:sponsorship_list"),
+        name="index",
+    ),
     path(
         "new",
         views.SponsorshipProfileCreate.as_view(),

--- a/templates/team/index.html
+++ b/templates/team/index.html
@@ -19,6 +19,69 @@
                 {% endfor %}
             </div>
         {% endif %}
+        {# Stat header — same pattern as the sponsorship list. #}
+        <div class="container border rounded-3 p-3 mb-4">
+            <div class="row text-center text-sm-start">
+                <div class="col-sm-3">
+                    <div class="card border-0">
+                        <div class="card-body">
+                            <h5 class="card-title">
+                                {% trans "Onboarded" %}
+                            </h5>
+                            <h1 class="display-4 text-primary">
+                                {{ onboarded_count }}
+                            </h1>
+                            <span class="text-muted">{% trans "approved volunteers" %}</span>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-sm-3">
+                    <div class="card border-0">
+                        <div class="card-body">
+                            <h5 class="card-title">
+                                {% trans "Active teams" %}
+                            </h5>
+                            <h1 class="display-4">
+                                {{ teams_count }}
+                            </h1>
+                            <span class="text-muted">{% blocktranslate %}{{ open_count }} open{% endblocktranslate %}</span>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-sm-3">
+                    <div class="card border-0">
+                        <div class="card-body">
+                            <h5 class="card-title">
+                                {% trans "Pending review" %}
+                            </h5>
+                            <h1 class="display-4 text-warning">
+                                {{ pending_total }}
+                            </h1>
+                            <span class="text-muted">{% trans "across all teams" %}</span>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-sm-3">
+                    <div class="card border-0">
+                        <div class="card-body">
+                            <h5 class="card-title">
+                                {% trans "Languages" %}
+                            </h5>
+                            <h1 class="display-4">
+                                {{ languages_count }}
+                            </h1>
+                            <span class="text-muted">{% trans "covered" %}</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        {% if unled_count %}
+            <div class="alert alert-warning d-flex align-items-center" role="alert">
+                <i class="fa-solid fa-triangle-exclamation fa-fw me-2"></i>
+                {% blocktranslate count counter=unled_count %}{{ counter }} team has no lead assigned.{% plural %}{{ counter }} teams have no lead assigned.{% endblocktranslate %}
+            </div>
+        {% endif %}
         <table class="table table-hover align-middle">
             <thead class="table-light">
                 <tr>
@@ -26,7 +89,7 @@
                         {% trans "Name" %}
                     </th>
                     <th>
-                        {% trans "Description" %}
+                        {% trans "Leads" %}
                     </th>
                     <th>
                         {% trans "Open" %}
@@ -45,7 +108,11 @@
                             <a href="{% url 'team_dashboard' team.id %}">{{ team.short_name }}</a>
                         </td>
                         <td>
-                            {{ team.description|truncatechars:60 }}
+                            {% for lead in team.team_leads.all %}
+                                <span class="badge text-bg-light border">{{ lead.user.get_full_name|default:lead.user.username }}</span>
+                            {% empty %}
+                                <span class="badge text-bg-danger">{% trans "unassigned" %}</span>
+                            {% endfor %}
                         </td>
                         <td>
                             {% if team.open_to_new_members %}
@@ -57,7 +124,7 @@
                         <td>
                             <span class="badge bg-primary rounded-pill" title="Approved">{{ team.approved_members.count }}</span>
                             <span class="badge bg-warning rounded-pill" title="Pending">{{ team.pending_members.count }}</span>
-                            <span class="badge bg-warning rounded-pill" title="Waitlisted">{{ team.waitlisted_members.count }}</span>
+                            <span class="badge bg-secondary rounded-pill" title="Waitlisted">{{ team.waitlisted_members.count }}</span>
                         </td>
                         <td>
                             <a href="{% url 'team_edit' team.id %}"

--- a/templates/volunteer/index.html
+++ b/templates/volunteer/index.html
@@ -1,118 +1,156 @@
 {% extends "portal/base.html" %}
 {% load allauth i18n %}
 {% load django_bootstrap5 %}
-{% load portal_extras %}
 {% block body %}
 {% endblock body %}
 {% block content %}
-    {% if profile and profile.is_approved and not profile.github_username %}
-        <div class="alert alert-warning alert-dismissible fade show" role="alert">
-            <h4 class="alert-heading">
-                <i class="fa-brands fa-github"></i> GitHub Username Required
-            </h4>
-            <p>
-                Your GitHub username is currently missing. You will be added to the
-                <a href="https://github.com/orgs/pyladies/teams/pyladiescon-volunteers"
-                   target="_blank"
-                   class="alert-link">@pyladies/pyladiescon-volunteers</a>
-                GitHub team to access our repositories.
-            </p>
-            <hr>
-            <p class="mb-0">
-                Please <a href="{% url 'volunteer:volunteer_profile_edit' profile.id %}"
-    class="alert-link"><strong>update your profile</strong></a>
-                with your GitHub username and let your team lead know after you've done that.
-            </p>
-            <button type="button"
-                    class="btn-close"
-                    data-bs-dismiss="alert"
-                    aria-label="Close">
-            </button>
-        </div>
-    {% endif %}
-    {% if user.is_superuser %}
-        <h1 class="display-5">
-            Manage Volunteers
+    <div class="container px-0">
+        <h1 class="h3 mb-4">
+            {% trans "My volunteering" %}
         </h1>
-        <p>
-            Review volunteer applications and manage team members.
-        </p>
-        <ul class="list-unstyled ps-8">
-            <li>
-                <a href="{% url 'volunteer:volunteers_list' %}" class="icon-link">
-                    {% translate "Manage Volunteers" %}
-                    <i class="fa-solid fa-chevron-right"></i>
-                </a>
-            </li>
-        </ul>
-    {% endif %}
-    <h1 class="display-5">
-        {% trans "Volunteer Profile" %}
-    </h1>
-    {% if profile %}
-        <div>
-            <a class="btn btn-primary btn-lg"
-               role="button"
-               href="{% url 'volunteer:volunteer_profile_detail' profile.id %}">View my Profile</a>
-            <a class="btn btn-secondary btn-lg"
-               role="button"
-               href="{% url 'volunteer:volunteer_profile_edit' profile.id %}">Edit Profile</a>
-        </div>
-    {% else %}
-        <p class="col-md-8 fs-4">
-            {% blocktranslate %}You have not created your Volunteer Profile yet. Once you created your profile, our team will review it.
-            We will then assign you to the appropriate team that needs help so you can get set up with the
-            necessary access.{% endblocktranslate %}
-        </p>
-        <a class="btn btn-primary btn-lg"
-           role="button"
-           href="{% url 'volunteer:volunteer_profile_new' %}">{% trans "Create my Profile" %}</a>
-    {% endif %}
-    <p>
-        <h2>
-            Links and Resources
-        </h2>
-        <ul class="list-unstyled ps-8">
-            <li>
-                <a href="{% url 'volunteer:my_conferences' %}" class="icon-link">
-                    Your Conferences
-                    <i class="fa-solid fa-chevron-right"></i>
-                </a> See all the editions you have volunteered for.
-            </li>
-            {% if profile.id %}
-                <li>
-                    <a href="{% url 'volunteer:index' %}" class="icon-link">
-                        Manage your volunteer profile
-                        <i class="fa-solid fa-chevron-right"></i>
-                    </a>
-                </li>
+        {% if not profile %}
+            {# No profile yet — prompt + what to expect. #}
+            <div class="card mb-4">
+                <div class="card-body">
+                    <h2 class="h5">
+                        {% trans "Start volunteering with PyLadiesCon" %}
+                    </h2>
+                    <p class="text-secondary">
+                        {% blocktranslate %}Create your volunteer profile and our team will review it, then match you to a team that needs help.{% endblocktranslate %}
+                    </p>
+                    <ol class="text-secondary">
+                        <li>
+                            {% trans "Fill in your profile — region, languages, and how you'd like to help." %}
+                        </li>
+                        <li>
+                            {% trans "We review it and match you to a team." %}
+                        </li>
+                        <li>
+                            {% trans "You get access to the tools and Discord once onboarded." %}
+                        </li>
+                    </ol>
+                    <a class="btn btn-primary"
+                       href="{% url 'volunteer:volunteer_profile_new' %}">{% trans "Create my volunteer profile" %}</a>
+                </div>
+            </div>
+        {% else %}
+            {# Status banner — the state-aware heart of the page. #}
+            {% if profile.is_approved %}
+                <div class="card border-success-subtle bg-success-subtle mb-4">
+                    <div class="card-body d-flex flex-wrap align-items-center gap-3">
+                        <i class="fa-solid fa-circle-check fs-3 text-success"></i>
+                        <div class="flex-grow-1">
+                            <div class="fw-semibold">
+                                {% trans "Approved volunteer" %}
+                                {% if profile.conference %}
+                                    · {{ profile.conference.year }}
+                                {% endif %}
+                            </div>
+                            <div class="small text-success-emphasis">
+                                {% if profile.region %}
+                                    {{ profile.region }}
+                                {% endif %}
+                                {% for lang in profile.language.all %}
+                                    {% if forloop.first and profile.region %}
+                                        ·
+                                    {% endif %}
+                                    {% if not forloop.first %}
+                                        ,
+                                    {% endif %}
+                                    {{ lang }}
+                                {% endfor %}
+                            </div>
+                        </div>
+                        <div class="d-flex gap-2">
+                            <a class="btn btn-sm btn-outline-secondary"
+                               href="{% url 'volunteer:volunteer_profile_detail' profile.id %}"><i class="fa-solid fa-eye"></i> {% trans "View" %}</a>
+                            <a class="btn btn-sm btn-outline-secondary"
+                               href="{% url 'volunteer:volunteer_profile_edit' profile.id %}"><i class="fa-solid fa-pencil"></i> {% trans "Edit" %}</a>
+                        </div>
+                    </div>
+                </div>
+                {% if not profile.github_username %}
+                    <div class="alert alert-warning" role="alert">
+                        <i class="fa-brands fa-github"></i>
+                        {% trans "Your GitHub username is missing — add it so we can grant repository access." %}
+                        <a href="{% url 'volunteer:volunteer_profile_edit' profile.id %}"
+                           class="alert-link">{% trans "Update profile" %}</a>
+                    </div>
+                {% endif %}
             {% else %}
-                <li>
-                    <a href="{% url 'volunteer:volunteer_profile_new' %}" class="icon-link">
-                        Volunteer Now
-                        <i class="fa-solid fa-chevron-right"></i>
-                    </a>
-                </li>
+                <div class="card border-warning-subtle bg-warning-subtle mb-4">
+                    <div class="card-body d-flex flex-wrap align-items-center gap-3">
+                        <i class="fa-solid fa-clock fs-3 text-warning"></i>
+                        <div class="flex-grow-1">
+                            <div class="fw-semibold">
+                                {% trans "Application under review" %}
+                            </div>
+                            <div class="small text-warning-emphasis">
+                                {% blocktranslate %}We'll email you once a team picks you up.{% endblocktranslate %}
+                            </div>
+                        </div>
+                        <div class="d-flex gap-2">
+                            <a class="btn btn-sm btn-outline-secondary"
+                               href="{% url 'volunteer:volunteer_profile_detail' profile.id %}"><i class="fa-solid fa-eye"></i> {% trans "View" %}</a>
+                            <a class="btn btn-sm btn-outline-secondary"
+                               href="{% url 'volunteer:volunteer_profile_edit' profile.id %}"><i class="fa-solid fa-pencil"></i> {% trans "Edit" %}</a>
+                        </div>
+                    </div>
+                </div>
             {% endif %}
-            <li>
-                <a href="https://conference.pyladies.com/docs/" class="icon-link">
-                    Team Descriptions
-                    <i class="fa-solid fa-chevron-right"></i>
-                </a> Learn about the different teams and their roles.
-            </li>
-            <li>
-                <a href="https://conference.pyladies.com/docs/roles_and_responsibilities/"
-                   class="icon-link">
-                    Volunteer Responsibilities
-                    <i class="fa-solid fa-chevron-right"></i>
-                </a> Understand the expectations and responsibilities of a volunteer.
-            </li>
-            <li>
-                <a href="https://discord.com/invite/2fUN4ddVfP" class="icon-link">
-                    Join our Discord
-                    <i class="fa-brands fa-discord"></i>
-                </a> All of our volunteers are required to be in our Discord server.
-            </li>
-        </ul>
-    </p>
+            {# My teams — leads link to the dashboard (slice 1); members are view-only. #}
+            <h2 class="h6 text-secondary mb-2">
+                {% trans "My teams" %}
+            </h2>
+            {% if my_teams %}
+                <div class="list-group mb-4">
+                    {% for team in my_teams %}
+                        <div class="list-group-item d-flex align-items-center gap-3">
+                            <i class="fa-solid fa-users-rectangle text-secondary"></i>
+                            <span class="flex-grow-1">
+                                <span class="fw-semibold">{{ team.short_name }}</span>
+                                {% if team.id in led_team_ids %}
+                                    <span class="badge text-bg-success ms-1">{% trans "Lead" %}</span>
+                                    <small class="d-block text-secondary">
+                                        {% blocktranslate count counter=team.approved_members.count %}{{ counter }} approved{% plural %}{{ counter }} approved{% endblocktranslate %}
+                                        ·
+                                        {% blocktranslate count counter=team.pending_members.count %}{{ counter }} pending review{% plural %}{{ counter }} pending review{% endblocktranslate %}
+                                    </small>
+                                {% else %}
+                                    <span class="badge text-bg-light border ms-1">{% trans "Member" %}</span>
+                                {% endif %}
+                            </span>
+                            {% if team.id in led_team_ids %}
+                                <a class="btn btn-sm btn-outline-primary"
+                                   href="{% url 'team_dashboard' team.id %}"><i class="fa-solid fa-gauge-high"></i> {% trans "Open dashboard" %}</a>
+                            {% endif %}
+                        </div>
+                    {% endfor %}
+                </div>
+            {% elif profile.is_approved %}
+                <div class="alert alert-light border mb-4">
+                    {% trans "You'll be assigned to a team soon." %}
+                </div>
+            {% else %}
+                <div class="alert alert-light border mb-4">
+                    {% trans "You'll see your team here once your application is approved." %}
+                </div>
+            {% endif %}
+            {# My conferences. #}
+            <h2 class="h6 text-secondary mb-2">
+                {% trans "My conferences" %}
+            </h2>
+            <div class="list-group mb-4">
+                <a href="{% url 'volunteer:my_conferences' %}"
+                   class="list-group-item list-group-item-action d-flex align-items-center">
+                    <i class="fa-solid fa-calendar-days fa-fw text-secondary me-3"></i>
+                    <span class="flex-grow-1">
+                        <span class="d-block">{% trans "Editions you've volunteered for" %}</span>
+                        <small class="text-secondary">{% blocktranslate count counter=conferences_count %}{{ counter }} edition{% plural %}{{ counter }} editions{% endblocktranslate %}</small>
+                    </span>
+                    <i class="fa-solid fa-chevron-right text-secondary"></i>
+                </a>
+            </div>
+        {% endif %}
+    </div>
 {% endblock content %}

--- a/tests/sponsorship/test_views.py
+++ b/tests/sponsorship/test_views.py
@@ -917,3 +917,11 @@ class TestSponsorActionsColumn:
             "sponsorship:sponsorship_profile_edit", kwargs={"pk": profile.pk}
         )
         assert edit_url in response.content.decode()
+
+
+@pytest.mark.django_db
+class TestSponsorshipIndexRedirect:
+    def test_root_redirects_to_list(self, client):
+        response = client.get(reverse("sponsorship:index"))
+        assert response.status_code == 302
+        assert response.url == reverse("sponsorship:sponsorship_list")

--- a/tests/volunteer/test_views.py
+++ b/tests/volunteer/test_views.py
@@ -1238,6 +1238,19 @@ class TestTeamList:
         response = client.get(reverse("teams"))
         assert reverse("team_edit", kwargs={"pk": team.pk}) in response.content.decode()
 
+    def test_stats_header_zeroes_without_active_conference(
+        self, client, admin_user, conference
+    ):
+        conference.is_active = False
+        conference.save()
+        client.force_login(admin_user)
+        response = client.get(reverse("teams"))
+        assert response.status_code == 200
+        assert response.context["selected_conference"] is None
+        assert response.context["onboarded_count"] == 0
+        assert response.context["teams_count"] == 0
+        assert response.context["languages_count"] == 0
+
 
 @pytest.mark.django_db
 class TestTeamCRUD:

--- a/volunteer/views.py
+++ b/volunteer/views.py
@@ -20,6 +20,11 @@ from common.mixins import (
     VolunteerOrAdminRequiredMixin,
 )
 from common.tasks import enqueue
+from portal.common import (
+    get_volunteer_languages_stat_cache,
+    get_volunteer_onboarded_stat_cache,
+    get_volunteer_teams_stat_cache,
+)
 from portal.models import Conference
 
 from .forms import TeamForm, VolunteerProfileForm, VolunteerProfileReviewForm
@@ -38,12 +43,25 @@ from .tasks import (
 @login_required
 def index(request):
     context = {}
-    # A user can have one profile per conference; show the active edition's.
-    # ``conference=None`` (no active conference) matches nothing, so this
-    # safely yields no profile rather than an arbitrary year.
-    context["profile"] = VolunteerProfile.objects.filter(
+    # One profile per conference; show the active edition's.
+    profile = VolunteerProfile.objects.filter(
         user=request.user, conference=Conference.get_active()
     ).first()
+    context["profile"] = profile
+
+    # Personal hub data: the teams this volunteer is on, and which of those they
+    # lead (so the template can link leads to the team dashboard from slice 1).
+    if profile:
+        context["my_teams"] = list(profile.teams.all())
+        context["led_team_ids"] = set(profile.team_leads.values_list("id", flat=True))
+    else:
+        context["my_teams"] = []
+        context["led_team_ids"] = set()
+
+    # Editions volunteered for = one profile per conference for this user.
+    context["conferences_count"] = VolunteerProfile.objects.filter(
+        user=request.user
+    ).count()
     return render(request, "volunteer/index.html", context)
 
 
@@ -357,8 +375,24 @@ class TeamList(VolunteerAdminRequiredMixin, ListView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        conference = self.get_selected_conference()
         context["conferences"] = Conference.objects.all()
-        context["selected_conference"] = self.get_selected_conference()
+        context["selected_conference"] = conference
+
+        teams = context["teams"]
+        if conference:
+            context["onboarded_count"] = get_volunteer_onboarded_stat_cache(conference)
+            context["teams_count"] = get_volunteer_teams_stat_cache(conference)
+            context["languages_count"] = get_volunteer_languages_stat_cache(conference)
+        else:
+            context["onboarded_count"] = 0
+            context["teams_count"] = 0
+            context["languages_count"] = 0
+
+        # Cross-team aggregates the bare list never surfaced.
+        context["pending_total"] = sum(t.pending_members.count() for t in teams)
+        context["open_count"] = sum(1 for t in teams if t.open_to_new_members)
+        context["unled_count"] = sum(1 for t in teams if not t.team_leads.exists())
         return context
 
 


### PR DESCRIPTION
Next redesign slice. The principle: build a landing only where there's personal, many-faceted state to aggregate; everywhere else, make the primary list a stats-topped dashboard and redirect the bare root to it.

## What changed
- **`volunteer/`** → a real **personal hub**: status-aware banner (approved / under-review, with a GitHub-username nudge), **My teams** (leads get an "Open dashboard" link to slice 1's dashboard, members get a view-only badge), and **My conferences**. `index()` now passes `my_teams`, `led_team_ids`, and `conferences_count`. The duplicated org-management block and external-link pile are gone — they live in the Organize nav and the Resources section now.
- **`teams/`** → the list **becomes a dashboard**: onboarded / active-teams / pending-across-all-teams / languages stat header (reusing the cached `get_volunteer_*_stat_cache` helpers), a **Leads** column, an **unassigned-lead** alert, and team names linking to the per-team dashboard.
- **`sponsorship/`** → no bespoke index; bare `/sponsorship/` now **redirects** to the stats-topped list instead of 404-ing.

## Adaptations / verifications
- Kept `@login_required` on the rewritten `index()` (the bundle omitted it).
- Confirmed the helpers (`get_volunteer_onboarded/teams/languages_stat_cache`) and reverse accessors (`profile.teams`, `profile.team_leads`) exist.
- Fixed the volunteer template's djlint issues (dropped an inline `max-width`; `&middot;` → `·`).

## Tests
- New: teams stat header zeroes with no active edition; `/sponsorship/` redirects to the list.
- **501 pass, 100% coverage**; black/isort/flake8/djlint clean; no schema change.

Refs #321