### PR TITLE
Add breadcrumb navigation across content pages

### DIFF
--- a/sponsorship/templates/sponsorship/sponsorship_profile_confirm_delete.html
+++ b/sponsorship/templates/sponsorship/sponsorship_profile_confirm_delete.html
@@ -1,5 +1,11 @@
 {% extends "portal/base.html" %}
 {% load i18n %}
+{% block breadcrumb %}
+    {% url 'sponsorship:sponsorship_list' as bc_url %}
+    {% trans "Sponsorship" as bc_section %}
+    {% trans "Delete" as bc_page %}
+    {% include "portal/_breadcrumbs.html" with section=bc_section section_url=bc_url page=bc_page %}
+{% endblock breadcrumb %}
 {% block content %}
     <div class="container px-4 py-3">
         <h1 class="display-6 pb-2 border-bottom">

--- a/sponsorship/templates/sponsorship/sponsorship_profile_form.html
+++ b/sponsorship/templates/sponsorship/sponsorship_profile_form.html
@@ -5,6 +5,16 @@
 {% block extra_head %}
     {{ block.super }}
 {% endblock extra_head %}
+{% block breadcrumb %}
+    {% url 'sponsorship:sponsorship_list' as bc_url %}
+    {% trans "Sponsorship" as bc_section %}
+    {% if object.pk %}
+        {% trans "Edit" as bc_page %}
+    {% else %}
+        {% trans "New" as bc_page %}
+    {% endif %}
+    {% include "portal/_breadcrumbs.html" with section=bc_section section_url=bc_url page=bc_page %}
+{% endblock breadcrumb %}
 {% block content %}
     <main>
         <h1 class="display-5">

--- a/sponsorship/templates/sponsorship/sponsorshipprofile_list.html
+++ b/sponsorship/templates/sponsorship/sponsorshipprofile_list.html
@@ -4,6 +4,10 @@
 {% load render_table from django_tables2 %}
 {% block body %}
 {% endblock body %}
+{% block breadcrumb %}
+    {% trans "Sponsorship" as bc_section %}
+    {% include "portal/_breadcrumbs.html" with section=bc_section %}
+{% endblock breadcrumb %}
 {% block content %}
     <h1 class="display-5">
         {% if request.user.is_superuser %}

--- a/sponsorship/templates/sponsorship/sponsorshiptier_confirm_delete.html
+++ b/sponsorship/templates/sponsorship/sponsorshiptier_confirm_delete.html
@@ -1,5 +1,11 @@
 {% extends "portal/base.html" %}
 {% load i18n %}
+{% block breadcrumb %}
+    {% url 'sponsorship:tier_list' as bc_url %}
+    {% trans "Tiers" as bc_section %}
+    {% trans "Delete" as bc_page %}
+    {% include "portal/_breadcrumbs.html" with section=bc_section section_url=bc_url page=bc_page %}
+{% endblock breadcrumb %}
 {% block content %}
     <div class="container px-4 py-3">
         <h1 class="display-6 pb-2 border-bottom">

--- a/sponsorship/templates/sponsorship/sponsorshiptier_form.html
+++ b/sponsorship/templates/sponsorship/sponsorshiptier_form.html
@@ -1,11 +1,18 @@
 {% extends "portal/base.html" %}
 {% load i18n %}
 {% load django_bootstrap5 %}
+{% block breadcrumb %}
+    {% url 'sponsorship:tier_list' as bc_url %}
+    {% trans "Tiers" as bc_section %}
+    {% if object.pk %}
+        {% trans "Edit" as bc_page %}
+    {% else %}
+        {% trans "New" as bc_page %}
+    {% endif %}
+    {% include "portal/_breadcrumbs.html" with section=bc_section section_url=bc_url page=bc_page %}
+{% endblock breadcrumb %}
 {% block content %}
     <div class="container px-4 py-3">
-        <p>
-            <a href="{% url 'sponsorship:tier_list' %}"><i class="fa-solid fa-arrow-left"></i> {% trans "All tiers" %}</a>
-        </p>
         <h1 class="display-6 pb-2 border-bottom">
             {% if object.pk %}
                 {% trans "Edit Sponsorship Tier" %}

--- a/sponsorship/templates/sponsorship/sponsorshiptier_list.html
+++ b/sponsorship/templates/sponsorship/sponsorshiptier_list.html
@@ -1,5 +1,11 @@
 {% extends "portal/base.html" %}
 {% load i18n %}
+{% block breadcrumb %}
+    {% url 'sponsorship:sponsorship_list' as bc_url %}
+    {% trans "Sponsorship" as bc_section %}
+    {% trans "Tiers" as bc_page %}
+    {% include "portal/_breadcrumbs.html" with section=bc_section section_url=bc_url page=bc_page %}
+{% endblock breadcrumb %}
 {% block content %}
     <div class="container px-4 py-3">
         <h1 class="display-5">

--- a/templates/portal/_breadcrumbs.html
+++ b/templates/portal/_breadcrumbs.html
@@ -1,0 +1,29 @@
+{% load i18n %}
+{% comment %}
+Reusable breadcrumb. Always starts at Home. Pass:
+section / section_url (optional middle crumb; linked when section_url given),
+page (optional final, current-page crumb).
+{% endcomment %}
+<nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+        <li class="breadcrumb-item">
+            <a href="{% url 'index' %}">{% trans "Home" %}</a>
+        </li>
+        {% if section %}
+            {% if section_url %}
+                <li class="breadcrumb-item">
+                    <a href="{{ section_url }}">{{ section }}</a>
+                </li>
+            {% else %}
+                <li class="breadcrumb-item active" aria-current="page">
+                    {{ section }}
+                </li>
+            {% endif %}
+        {% endif %}
+        {% if page %}
+            <li class="breadcrumb-item active" aria-current="page">
+                {{ page }}
+            </li>
+        {% endif %}
+    </ol>
+</nav>

--- a/templates/portal/base.html
+++ b/templates/portal/base.html
@@ -203,6 +203,8 @@
             </div>
         </nav>
         <div class="container my-5">
+            {% block breadcrumb %}
+            {% endblock breadcrumb %}
             {% block content %}
             {% endblock content %}
         </div>

--- a/templates/portal/conference_confirm_delete.html
+++ b/templates/portal/conference_confirm_delete.html
@@ -1,5 +1,11 @@
 {% extends "portal/base.html" %}
 {% load i18n %}
+{% block breadcrumb %}
+    {% url 'conference_list' as bc_url %}
+    {% trans "Conferences" as bc_section %}
+    {% trans "Delete" as bc_page %}
+    {% include "portal/_breadcrumbs.html" with section=bc_section section_url=bc_url page=bc_page %}
+{% endblock breadcrumb %}
 {% block content %}
     <div class="container px-4 py-3">
         <h1 class="display-6 pb-2 border-bottom">

--- a/templates/portal/conference_form.html
+++ b/templates/portal/conference_form.html
@@ -1,11 +1,14 @@
 {% extends "portal/base.html" %}
 {% load i18n %}
 {% load django_bootstrap5 %}
+{% block breadcrumb %}
+    {% url 'conference_list' as bc_url %}
+    {% trans "Conferences" as bc_section %}
+    {% trans "Edit" as bc_page %}
+    {% include "portal/_breadcrumbs.html" with section=bc_section section_url=bc_url page=bc_page %}
+{% endblock breadcrumb %}
 {% block content %}
     <div class="container px-4 py-3">
-        <p>
-            <a href="{% url 'conference_list' %}"><i class="fa-solid fa-arrow-left"></i> {% trans "All conferences" %}</a>
-        </p>
         <h1 class="display-6 pb-2 border-bottom">
             {% trans "Edit Conference" %}: {{ object.name }}
         </h1>

--- a/templates/portal/conference_list.html
+++ b/templates/portal/conference_list.html
@@ -1,5 +1,9 @@
 {% extends "portal/base.html" %}
 {% load i18n %}
+{% block breadcrumb %}
+    {% trans "Conferences" as bc_section %}
+    {% include "portal/_breadcrumbs.html" with section=bc_section %}
+{% endblock breadcrumb %}
 {% block content %}
     <div class="container px-4 py-3">
         <h1 class="display-6 pb-2 border-bottom">

--- a/templates/portal_account/index.html
+++ b/templates/portal_account/index.html
@@ -3,6 +3,10 @@
 {% load django_bootstrap5 %}
 {% block body %}
 {% endblock body %}
+{% block breadcrumb %}
+    {% trans "Account" as bc_section %}
+    {% include "portal/_breadcrumbs.html" with section=bc_section %}
+{% endblock breadcrumb %}
 {% block content %}
     <div class="container px-0">
         <h1 class="h3 mb-4">

--- a/templates/portal_account/portalprofile_detail.html
+++ b/templates/portal_account/portalprofile_detail.html
@@ -3,10 +3,13 @@
 {% load django_bootstrap5 %}
 {% block body %}
 {% endblock body %}
+{% block breadcrumb %}
+    {% url 'portal_account:index' as bc_url %}
+    {% trans "Account" as bc_section %}
+    {% trans "Profile" as bc_page %}
+    {% include "portal/_breadcrumbs.html" with section=bc_section section_url=bc_url page=bc_page %}
+{% endblock breadcrumb %}
 {% block content %}
-    <p>
-        <a href="{% url 'portal_account:index' %}"><i class="fa-solid fa-arrow-left"></i> {% trans "Account" %}</a>
-    </p>
     <h1 class="display-5 mb-4">
         {% trans "Your Portal Profile" %}
     </h1>

--- a/templates/portal_account/portalprofile_form.html
+++ b/templates/portal_account/portalprofile_form.html
@@ -3,11 +3,18 @@
 {% load django_bootstrap5 %}
 {% block body %}
 {% endblock body %}
+{% block breadcrumb %}
+    {% url 'portal_account:index' as bc_url %}
+    {% trans "Account" as bc_section %}
+    {% if object.pk %}
+        {% trans "Edit profile" as bc_page %}
+    {% else %}
+        {% trans "Create profile" as bc_page %}
+    {% endif %}
+    {% include "portal/_breadcrumbs.html" with section=bc_section section_url=bc_url page=bc_page %}
+{% endblock breadcrumb %}
 {% block content %}
     <main>
-        <p>
-            <a href="{% url 'portal_account:index' %}"><i class="fa-solid fa-arrow-left"></i> {% trans "Account" %}</a>
-        </p>
         <h1 class="display-5">
             {% if object.pk %}
                 {% trans "Edit" %}

--- a/templates/team/index.html
+++ b/templates/team/index.html
@@ -3,6 +3,10 @@
 {% load django_bootstrap5 %}
 {% block body %}
 {% endblock body %}
+{% block breadcrumb %}
+    {% trans "Teams" as bc_section %}
+    {% include "portal/_breadcrumbs.html" with section=bc_section %}
+{% endblock breadcrumb %}
 {% block content %}
     <div class="container px-4 py-5" id="featured-3">
         <h1 class="display-5">

--- a/templates/team/my_teams.html
+++ b/templates/team/my_teams.html
@@ -1,5 +1,9 @@
 {% extends "portal/base.html" %}
 {% load i18n %}
+{% block breadcrumb %}
+    {% trans "My teams" as bc_section %}
+    {% include "portal/_breadcrumbs.html" with section=bc_section %}
+{% endblock breadcrumb %}
 {% block content %}
     <div class="container px-4 py-4">
         <h1 class="display-6 pb-2 border-bottom">

--- a/templates/team/team_confirm_delete.html
+++ b/templates/team/team_confirm_delete.html
@@ -1,5 +1,11 @@
 {% extends "portal/base.html" %}
 {% load i18n %}
+{% block breadcrumb %}
+    {% url 'teams' as bc_url %}
+    {% trans "Teams" as bc_section %}
+    {% trans "Delete" as bc_page %}
+    {% include "portal/_breadcrumbs.html" with section=bc_section section_url=bc_url page=bc_page %}
+{% endblock breadcrumb %}
 {% block content %}
     <div class="container px-4 py-3">
         <h1 class="display-6 pb-2 border-bottom">

--- a/templates/team/team_dashboard.html
+++ b/templates/team/team_dashboard.html
@@ -3,11 +3,18 @@
 {% load django_bootstrap5 %}
 {% block body %}
 {% endblock body %}
+{% block breadcrumb %}
+    {% if is_organizer %}
+        {% url 'teams' as bc_url %}
+        {% trans "Teams" as bc_section %}
+    {% else %}
+        {% url 'my_teams' as bc_url %}
+        {% trans "My teams" as bc_section %}
+    {% endif %}
+    {% include "portal/_breadcrumbs.html" with section=bc_section section_url=bc_url page=team.short_name %}
+{% endblock breadcrumb %}
 {% block content %}
     <div class="container px-4 py-4">
-        <p>
-            <a href="{% url 'teams' %}"><i class="fa-solid fa-arrow-left"></i> {% trans "All teams" %}</a>
-        </p>
         <h1 class="display-6 d-flex align-items-center flex-wrap gap-2">
             {{ team.short_name }}
             <span class="badge bg-secondary fs-6 align-middle">{{ team.conference.year }}</span>

--- a/templates/team/team_detail.html
+++ b/templates/team/team_detail.html
@@ -3,11 +3,13 @@
 {% load django_bootstrap5 %}
 {% block body %}
 {% endblock body %}
+{% block breadcrumb %}
+    {% url 'teams' as bc_url %}
+    {% trans "Teams" as bc_section %}
+    {% include "portal/_breadcrumbs.html" with section=bc_section section_url=bc_url page=team.short_name %}
+{% endblock breadcrumb %}
 {% block content %}
     <div class="container px-4 py-5" id="featured-3">
-        <p>
-            <a href="{% url 'teams' %}"><i class="fa-solid fa-arrow-left"></i> {% trans "All teams" %}</a>
-        </p>
         <h2 class="pb-2 border-bottom">
             {{ team.short_name }}
             <span class="badge bg-secondary align-middle fs-6">{{ team.conference }}</span>

--- a/templates/team/team_form.html
+++ b/templates/team/team_form.html
@@ -1,6 +1,16 @@
 {% extends "portal/base.html" %}
 {% load i18n %}
 {% load django_bootstrap5 %}
+{% block breadcrumb %}
+    {% url 'teams' as bc_url %}
+    {% trans "Teams" as bc_section %}
+    {% if form.instance.pk %}
+        {% trans "Edit team" as bc_page %}
+    {% else %}
+        {% trans "New team" as bc_page %}
+    {% endif %}
+    {% include "portal/_breadcrumbs.html" with section=bc_section section_url=bc_url page=bc_page %}
+{% endblock breadcrumb %}
 {% block content %}
     <div class="container px-4 py-3">
         <h1 class="display-6 pb-2 border-bottom">

--- a/templates/volunteer/index.html
+++ b/templates/volunteer/index.html
@@ -3,6 +3,10 @@
 {% load django_bootstrap5 %}
 {% block body %}
 {% endblock body %}
+{% block breadcrumb %}
+    {% trans "Volunteer" as bc_section %}
+    {% include "portal/_breadcrumbs.html" with section=bc_section %}
+{% endblock breadcrumb %}
 {% block content %}
     <div class="container px-0">
         <h1 class="h3 mb-4">

--- a/templates/volunteer/my_conferences.html
+++ b/templates/volunteer/my_conferences.html
@@ -1,5 +1,11 @@
 {% extends "portal/base.html" %}
 {% load i18n %}
+{% block breadcrumb %}
+    {% url 'volunteer:index' as bc_url %}
+    {% trans "Volunteer" as bc_section %}
+    {% trans "My conferences" as bc_page %}
+    {% include "portal/_breadcrumbs.html" with section=bc_section section_url=bc_url page=bc_page %}
+{% endblock breadcrumb %}
 {% block content %}
     <div class="container px-4 py-3">
         <h1 class="display-5">

--- a/templates/volunteer/volunteerprofile_detail.html
+++ b/templates/volunteer/volunteerprofile_detail.html
@@ -3,6 +3,12 @@
 {% load django_bootstrap5 %}
 {% block body %}
 {% endblock body %}
+{% block breadcrumb %}
+    {% url 'volunteer:index' as bc_url %}
+    {% trans "Volunteer" as bc_section %}
+    {% trans "Profile" as bc_page %}
+    {% include "portal/_breadcrumbs.html" with section=bc_section section_url=bc_url page=bc_page %}
+{% endblock breadcrumb %}
 {% block content %}
     <h1 class="display-5 mb-4">
         {% if user.is_superuser and user.username != object.user.username %}

--- a/templates/volunteer/volunteerprofile_form.html
+++ b/templates/volunteer/volunteerprofile_form.html
@@ -28,6 +28,16 @@
         }
     </style>
 {% endblock extra_head %}
+{% block breadcrumb %}
+    {% url 'volunteer:index' as bc_url %}
+    {% trans "Volunteer" as bc_section %}
+    {% if object.pk %}
+        {% trans "Edit profile" as bc_page %}
+    {% else %}
+        {% trans "New profile" as bc_page %}
+    {% endif %}
+    {% include "portal/_breadcrumbs.html" with section=bc_section section_url=bc_url page=bc_page %}
+{% endblock breadcrumb %}
 {% block content %}
     <main>
         <h1 class="display-5">

--- a/templates/volunteer/volunteerprofile_list.html
+++ b/templates/volunteer/volunteerprofile_list.html
@@ -4,6 +4,10 @@
 {% load render_table from django_tables2 %}
 {% block body %}
 {% endblock body %}
+{% block breadcrumb %}
+    {% trans "Volunteers" as bc_section %}
+    {% include "portal/_breadcrumbs.html" with section=bc_section %}
+{% endblock breadcrumb %}
 {% block content %}
     <h1 class="display-5">
         Manage Volunteers

--- a/templates/volunteer/volunteerprofile_review_form.html
+++ b/templates/volunteer/volunteerprofile_review_form.html
@@ -2,6 +2,11 @@
 {% load allauth i18n %}
 {% load django_bootstrap5 %}
 {% load static %}
+{% block breadcrumb %}
+    {% url 'volunteer:volunteers_list' as bc_url %}
+    {% trans "Volunteers" as bc_section %}
+    {% include "portal/_breadcrumbs.html" with section=bc_section section_url=bc_url page=object.user.username %}
+{% endblock breadcrumb %}
 {% block content %}
     <main>
         <h1 class="display-5">

--- a/tests/volunteer/test_views.py
+++ b/tests/volunteer/test_views.py
@@ -1445,3 +1445,43 @@ class TestMyTeams:
         client.force_login(portal_user)
         response = client.get(reverse("volunteer:index"))
         assert reverse("my_teams") not in response.content.decode()
+
+
+@pytest.mark.django_db
+class TestBreadcrumbs:
+    def test_list_breadcrumb_links_home(self, client, admin_user, conference):
+        client.force_login(admin_user)
+        response = client.get(reverse("teams"))
+        content = response.content.decode()
+        assert 'aria-label="breadcrumb"' in content
+        assert reverse("index") in content
+        # The template comment must not leak into the rendered page.
+        assert "Reusable breadcrumb" not in content
+
+    def test_dashboard_breadcrumb_for_admin_points_to_teams(
+        self, client, admin_user, conference
+    ):
+        team = Team.objects.create(
+            short_name="Comms", description="d", conference=conference
+        )
+        client.force_login(admin_user)
+        response = client.get(reverse("team_dashboard", kwargs={"pk": team.pk}))
+        content = response.content.decode()
+        assert 'aria-label="breadcrumb"' in content
+        assert reverse("teams") in content
+
+    def test_dashboard_breadcrumb_for_lead_points_to_my_teams(
+        self, client, portal_user, conference
+    ):
+        team = Team.objects.create(
+            short_name="Comms", description="d", conference=conference
+        )
+        lead = VolunteerProfile.objects.create(
+            user=portal_user,
+            conference=conference,
+            application_status=ApplicationStatus.APPROVED,
+        )
+        team.team_leads.add(lead)
+        client.force_login(portal_user)
+        response = client.get(reverse("team_dashboard", kwargs={"pk": team.pk}))
+        assert reverse("my_teams") in response.content.decode()


### PR DESCRIPTION
Adds the sub-navigation, a breadcrumb trail so you can see where you are and step back up (e.g. from a team page → Teams → Home), instead of only the site-wide top nav.

## What changed
- **Reusable include** `templates/portal/_breadcrumbs.html` + a `{% block breadcrumb %}` slot in `base.html` (rendered above page content). Always starts at **Home**; pass an optional middle `section`/`section_url` and a final `page`.
- Wired across **team** (list, my teams, dashboard, detail, form, delete), **volunteer** (hub, profile detail/form, my conferences, review, volunteers list), **sponsorship** (list, form, delete, tiers list/form/delete), **conference** (list/form/delete), and **account** (index/detail/form).
- The **team dashboard** trail adapts to the viewer: `Home / Teams / <team>` for organizers, `Home / My teams / <team>` for leads (who can't reach the admin teams list).
- Removed now-redundant ad-hoc back-links ("All teams", "All tiers", "All conferences", "Account").

## Notes
- `sponsorship_profile_detail` already had its own breadcrumb; left as-is.
- The include uses `{% comment %}`, **not** a multi-line `{# #}` — Django only recognizes `{# #}` on a single line, so a multi-line one renders as literal text (caught and fixed; a test guards against it leaking).

## Tests
- Breadcrumb renders with a Home link; dashboard trail points to Teams (organizer) vs My teams (lead); the template comment does not leak into the page.
- **504 pass, 100% coverage**; black/isort/flake8/djlint clean; no schema change.

Refs #321