### PR TITLE
Add an organizer dashboard (command center) for staff

### DIFF
--- a/portal/common.py
+++ b/portal/common.py
@@ -218,6 +218,14 @@ SPONSOR_PENDING_STATUS = [
     SponsorshipProgressStatus.AGREEMENT_SIGNED,
     SponsorshipProgressStatus.INVOICED,
 ]
+# "Committed but not yet invoiced" = committed statuses minus INVOICED/PAID.
+# Used by the organizer dashboard's needs-attention queue.
+SPONSOR_AWAITING_INVOICE_STATUS = [
+    SponsorshipProgressStatus.ACCEPTED,
+    SponsorshipProgressStatus.APPROVED,
+    SponsorshipProgressStatus.AGREEMENT_SENT,
+    SponsorshipProgressStatus.AGREEMENT_SIGNED,
+]
 
 
 def get_sponsorship_total_count_stats_cache(conference):

--- a/portal/urls.py
+++ b/portal/urls.py
@@ -26,6 +26,11 @@ from volunteer import views as volunteer_view
 
 urlpatterns = [
     path("", views.index, name="index"),
+    path(
+        "organize/",
+        views.OrganizerDashboardView.as_view(),
+        name="organizer_dashboard",
+    ),
     path("volunteer/", include("volunteer.urls", namespace="volunteer")),
     path("admin/", admin.site.urls),
     # Override two allauth views so finishing returns to the account page (the

--- a/portal/views.py
+++ b/portal/views.py
@@ -4,11 +4,25 @@ from django.db.models import ProtectedError
 from django.http import JsonResponse
 from django.shortcuts import redirect, render
 from django.urls import reverse_lazy
-from django.views.generic import ListView
+from django.views.generic import ListView, TemplateView
 from django.views.generic.edit import DeleteView, FormView, UpdateView
 
-from common.mixins import SuperuserRequiredMixin
-from portal.common import get_historical_comparison_data, get_stats_cached_values
+from common.mixins import AdminRequiredMixin, SuperuserRequiredMixin
+from portal.common import (
+    SPONSOR_AWAITING_INVOICE_STATUS,
+    get_historical_comparison_data,
+    get_stats_cached_values,
+)
+from portal.constants import (
+    CACHE_KEY_ATTENDEE_COUNT,
+    CACHE_KEY_ATTENDEE_FIRST_TIME_COUNT,
+    CACHE_KEY_DONATION_TOWARDS_GOAL_PERCENT,
+    CACHE_KEY_DONATIONS_TOTAL_AMOUNT,
+    CACHE_KEY_SPONSORSHIP_COMMITTED,
+    CACHE_KEY_SPONSORSHIP_TOWARDS_GOAL_PERCENT,
+    CACHE_KEY_VOLUNTEER_ONBOARDED_COUNT,
+    SPONSORSHIP_GOAL,
+)
 from portal.forms import ConferenceForm, StartNewYearForm
 from portal.models import Conference
 from portal.services import (
@@ -17,7 +31,8 @@ from portal.services import (
     clone_teams,
 )
 from portal_account.models import PortalProfile
-from volunteer.models import VolunteerProfile
+from sponsorship.models import SponsorshipProfile
+from volunteer.models import Team, VolunteerProfile
 
 
 def index(request):
@@ -32,6 +47,9 @@ def index(request):
     if user.is_authenticated:
         if not PortalProfile.objects.filter(user=user).exists():
             return redirect("portal_account:portal_profile_new")
+        # Organizers land on their command center, not the volunteer landing.
+        if user.is_superuser or user.is_staff:
+            return redirect("organizer_dashboard")
         volunteer_profile = VolunteerProfile.objects.filter(
             user=user, conference=Conference.get_active()
         ).first()
@@ -103,6 +121,58 @@ def dashboard_gallery(request):
     context = {}
 
     return render(request, "portal/dashboard_gallery.html", context)
+
+
+class OrganizerDashboardView(AdminRequiredMixin, TemplateView):
+    """Cross-app command center for organizers (superuser/staff).
+
+    A router, not a reimplementation: the top row reuses the same cached stats
+    as the public Stats page, and every action/attention item links to the
+    existing list views. Nothing here duplicates those surfaces.
+    """
+
+    template_name = "portal/organizer_dashboard.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        conference = Conference.get_active()
+        # Stats helpers assume an edition; with none active, fall back to empties
+        # so the dashboard renders zeros instead of erroring.
+        stats = get_stats_cached_values(conference) if conference else {}
+        context["conference"] = conference
+        context["can_start_next_year"] = Conference.can_start_next_year()
+
+        # Top-line cross-app numbers (clean keys for the template).
+        context["onboarded_count"] = stats.get(CACHE_KEY_VOLUNTEER_ONBOARDED_COUNT, 0)
+        context["sponsorship_goal_percent"] = stats.get(
+            CACHE_KEY_SPONSORSHIP_TOWARDS_GOAL_PERCENT, 0
+        )
+        context["sponsorship_committed"] = stats.get(CACHE_KEY_SPONSORSHIP_COMMITTED, 0)
+        context["sponsorship_goal"] = stats.get(SPONSORSHIP_GOAL, 0)
+        context["donation_goal_percent"] = stats.get(
+            CACHE_KEY_DONATION_TOWARDS_GOAL_PERCENT, 0
+        )
+        context["donations_total"] = stats.get(CACHE_KEY_DONATIONS_TOTAL_AMOUNT, 0)
+        context["donation_goal"] = conference.donation_goal if conference else 0
+        context["attendee_count"] = stats.get(CACHE_KEY_ATTENDEE_COUNT, 0)
+        context["attendee_first_time_count"] = stats.get(
+            CACHE_KEY_ATTENDEE_FIRST_TIME_COUNT, 0
+        )
+
+        # Needs-attention queue - all derivable, no new model fields.
+        if conference:
+            teams = Team.objects.filter(conference=conference)
+            context["pending_reviews"] = sum(t.pending_members.count() for t in teams)
+            context["unled_teams"] = sum(1 for t in teams if not t.team_leads.exists())
+            context["awaiting_invoice"] = SponsorshipProfile.objects.filter(
+                conference=conference,
+                progress_status__in=SPONSOR_AWAITING_INVOICE_STATUS,
+            ).count()
+        else:
+            context["pending_reviews"] = 0
+            context["unled_teams"] = 0
+            context["awaiting_invoice"] = 0
+        return context
 
 
 class StartNewYearView(SuperuserRequiredMixin, FormView):

--- a/templates/portal/base.html
+++ b/templates/portal/base.html
@@ -110,6 +110,12 @@
                                    aria-expanded="false">{% trans "Organize" %}</a>
                                 <ul class="dropdown-menu" aria-labelledby="navOrganize">
                                     <li>
+                                        <a class="dropdown-item" href="{% url 'organizer_dashboard' %}">{% trans "Dashboard" %}</a>
+                                    </li>
+                                    <li>
+                                        <hr class="dropdown-divider">
+                                    </li>
+                                    <li>
                                         <a class="dropdown-item" href="{% url 'volunteer:volunteers_list' %}">{% trans "Volunteers" %}</a>
                                     </li>
                                     <li>

--- a/templates/portal/organizer_dashboard.html
+++ b/templates/portal/organizer_dashboard.html
@@ -1,0 +1,190 @@
+{% extends "portal/base.html" %}
+{% load allauth i18n %}
+{% load django_bootstrap5 %}
+{% load portal_extras %}
+{% block body %}
+{% endblock body %}
+{% block content %}
+    <div class="container px-0">
+        <h1 class="h3 mb-1">
+            {% trans "Organizer dashboard" %}
+        </h1>
+        <p class="text-secondary mb-4">
+            {% if conference %}
+                {% blocktranslate with year=conference.year %}PyLadiesCon {{ year }} — everything that needs your eyes, in one place.{% endblocktranslate %}
+            {% else %}
+                {% trans "No active conference edition." %}
+            {% endif %}
+        </p>
+        {# ---- Cross-app top line ---- #}
+        <div class="row row-cols-2 row-cols-md-4 g-3 mb-4">
+            <div class="col">
+                <div class="card h-100">
+                    <div class="card-body">
+                        <div class="text-secondary small mb-1">
+                            <i class="fa-solid fa-user-check"></i> {% trans "Onboarded" %}
+                        </div>
+                        <div class="fs-3 fw-medium">
+                            {{ onboarded_count }}
+                        </div>
+                        <div class="text-muted small">
+                            {% trans "approved volunteers" %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="col">
+                <div class="card h-100">
+                    <div class="card-body">
+                        <div class="text-secondary small mb-1">
+                            <i class="fa-solid fa-hand-holding-dollar"></i> {% trans "Sponsorship" %}
+                        </div>
+                        <div class="fs-3 fw-medium">
+                            {{ sponsorship_goal_percent }}%
+                        </div>
+                        <div class="text-muted small">
+                            {{ sponsorship_committed|as_currency }} {% trans "of" %} {{ sponsorship_goal|as_currency }}
+                        </div>
+                        {# djlint:off #}
+                        <div class="progress mt-2" role="progressbar" style="height: 5px;">
+                            <div class="progress-bar" style="width: {{ sponsorship_goal_percent }}%"></div>
+                        </div>
+                        {# djlint:on #}
+                    </div>
+                </div>
+            </div>
+            <div class="col">
+                <div class="card h-100">
+                    <div class="card-body">
+                        <div class="text-secondary small mb-1">
+                            <i class="fa-solid fa-heart"></i> {% trans "Donations" %}
+                        </div>
+                        <div class="fs-3 fw-medium">
+                            {{ donation_goal_percent }}%
+                        </div>
+                        <div class="text-muted small">
+                            {{ donations_total|as_currency }} {% trans "of" %} {{ donation_goal|as_currency }}
+                        </div>
+                        {# djlint:off #}
+                        <div class="progress mt-2" role="progressbar" style="height: 5px;">
+                            <div class="progress-bar" style="width: {{ donation_goal_percent }}%"></div>
+                        </div>
+                        {# djlint:on #}
+                    </div>
+                </div>
+            </div>
+            <div class="col">
+                <div class="card h-100">
+                    <div class="card-body">
+                        <div class="text-secondary small mb-1">
+                            <i class="fa-solid fa-ticket"></i> {% trans "Attendees" %}
+                        </div>
+                        <div class="fs-3 fw-medium">
+                            {{ attendee_count }}
+                        </div>
+                        <div class="text-muted small">
+                            {% blocktranslate count counter=attendee_first_time_count %}{{ counter }} first-time{% plural %}{{ counter }} first-time{% endblocktranslate %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        {# ---- Needs attention ---- #}
+        <h2 class="h6 text-secondary mb-2">
+            {% trans "Needs attention" %}
+        </h2>
+        {% if pending_reviews or unled_teams or awaiting_invoice %}
+            <div class="list-group mb-4">
+                {% if pending_reviews %}
+                    <a href="{% url 'teams' %}"
+                       class="list-group-item list-group-item-action list-group-item-warning d-flex align-items-center">
+                        <i class="fa-solid fa-clipboard-list fa-fw me-3"></i>
+                        <span class="flex-grow-1">{% blocktranslate count counter=pending_reviews %}<strong>{{ counter }} volunteer application</strong> pending review.{% plural %}<strong>{{ counter }} volunteer applications</strong> pending review across teams.{% endblocktranslate %}</span>
+                        <i class="fa-solid fa-chevron-right"></i>
+                    </a>
+                {% endif %}
+                {% if unled_teams %}
+                    <a href="{% url 'teams' %}"
+                       class="list-group-item list-group-item-action list-group-item-warning d-flex align-items-center">
+                        <i class="fa-solid fa-user-slash fa-fw me-3"></i>
+                        <span class="flex-grow-1">{% blocktranslate count counter=unled_teams %}<strong>{{ counter }} team</strong> has no lead assigned.{% plural %}<strong>{{ counter }} teams</strong> have no lead assigned.{% endblocktranslate %}</span>
+                        <i class="fa-solid fa-chevron-right"></i>
+                    </a>
+                {% endif %}
+                {% if awaiting_invoice %}
+                    <a href="{% url 'sponsorship:sponsorship_list' %}"
+                       class="list-group-item list-group-item-action list-group-item-warning d-flex align-items-center">
+                        <i class="fa-solid fa-file-invoice fa-fw me-3"></i>
+                        <span class="flex-grow-1">{% blocktranslate count counter=awaiting_invoice %}<strong>{{ counter }} sponsor</strong> committed but not yet invoiced.{% plural %}<strong>{{ counter }} sponsors</strong> committed but not yet invoiced.{% endblocktranslate %}</span>
+                        <i class="fa-solid fa-chevron-right"></i>
+                    </a>
+                {% endif %}
+            </div>
+        {% else %}
+            <div class="alert alert-light border mb-4">
+                <i class="fa-solid fa-circle-check text-success"></i> {% trans "Nothing needs your attention right now." %}
+            </div>
+        {% endif %}
+        {# ---- Quick actions ---- #}
+        <h2 class="h6 text-secondary mb-2">
+            {% trans "Quick actions" %}
+        </h2>
+        <div class="row row-cols-2 row-cols-md-3 g-3">
+            <div class="col">
+                <a href="{% url 'volunteer:volunteers_list' %}"
+                   class="card h-100 text-decoration-none">
+                    <div class="card-body d-flex align-items-center gap-3">
+                        <i class="fa-solid fa-users fs-5 text-primary"></i>
+                        <span class="text-body">{% trans "Review volunteers" %}</span>
+                    </div>
+                </a>
+            </div>
+            <div class="col">
+                <a href="{% url 'teams' %}" class="card h-100 text-decoration-none">
+                    <div class="card-body d-flex align-items-center gap-3">
+                        <i class="fa-solid fa-users-rectangle fs-5 text-primary"></i>
+                        <span class="text-body">{% trans "Manage teams" %}</span>
+                    </div>
+                </a>
+            </div>
+            <div class="col">
+                <a href="{% url 'sponsorship:sponsorship_profile_new' %}"
+                   class="card h-100 text-decoration-none">
+                    <div class="card-body d-flex align-items-center gap-3">
+                        <i class="fa-solid fa-plus fs-5 text-primary"></i>
+                        <span class="text-body">{% trans "Add sponsor" %}</span>
+                    </div>
+                </a>
+            </div>
+            <div class="col">
+                <a href="{% url 'conference_list' %}"
+                   class="card h-100 text-decoration-none">
+                    <div class="card-body d-flex align-items-center gap-3">
+                        <i class="fa-solid fa-calendar-days fs-5 text-primary"></i>
+                        <span class="text-body">{% trans "Conferences" %}</span>
+                    </div>
+                </a>
+            </div>
+            {% if can_start_next_year %}
+                <div class="col">
+                    <a href="{% url 'start_new_year' %}"
+                       class="card h-100 text-decoration-none">
+                        <div class="card-body d-flex align-items-center gap-3">
+                            <i class="fa-solid fa-calendar-plus fs-5 text-primary"></i>
+                            <span class="text-body">{% trans "Start next year" %}</span>
+                        </div>
+                    </a>
+                </div>
+            {% endif %}
+            <div class="col">
+                <a href="{% url 'admin:index' %}"
+                   class="card h-100 text-decoration-none">
+                    <div class="card-body d-flex align-items-center gap-3">
+                        <i class="fa-solid fa-user-shield fs-5 text-primary"></i>
+                        <span class="text-body">{% trans "Admin area" %}</span>
+                    </div>
+                </a>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/tests/portal/test_views.py
+++ b/tests/portal/test_views.py
@@ -5,7 +5,11 @@ from pytest_django.asserts import assertRedirects
 
 from portal.models import Conference
 from portal_account.models import PortalProfile
-from sponsorship.models import SponsorshipTier
+from sponsorship.models import (
+    SponsorshipProfile,
+    SponsorshipProgressStatus,
+    SponsorshipTier,
+)
 from volunteer.constants import ApplicationStatus
 from volunteer.models import PyladiesChapter, Team, VolunteerProfile
 
@@ -47,22 +51,17 @@ class TestPortalIndex:
         assert "Sign out" not in response.content.decode()
         assert "Login" not in response.content.decode()
 
-    def test_organizer_tools_shown_to_superuser(self, client, admin_user, conference):
+    def test_organizer_redirected_to_dashboard(self, client, admin_user, conference):
         PortalProfile.objects.create(user=admin_user)
         client.force_login(admin_user)
         response = client.get(reverse("index"))
-        assert response.status_code == 200
-        content = response.content.decode()
-        assert "Organizer tools" in content
-        assert reverse("teams") in content
-        assert reverse("volunteer:volunteers_list") in content
+        assertRedirects(response, reverse("organizer_dashboard"))
 
-    def test_manage_tiers_link_shown_to_superuser(self, client, admin_user, conference):
-        PortalProfile.objects.create(user=admin_user)
-        client.force_login(admin_user)
+    def test_non_organizer_sees_landing(self, client, portal_user, conference):
+        PortalProfile.objects.create(user=portal_user)
+        client.force_login(portal_user)
         response = client.get(reverse("index"))
         assert response.status_code == 200
-        assert reverse("sponsorship:tier_list") in response.content.decode()
 
 
 @pytest.mark.django_db
@@ -293,17 +292,15 @@ class TestStartNextYearGate:
 
     def test_card_shown_when_date_passed(self, client, admin_user, conference):
         # autouse conference_date is in the past -> can start next year
-        PortalProfile.objects.create(user=admin_user)
         client.force_login(admin_user)
-        response = client.get(reverse("index"))
+        response = client.get(reverse("organizer_dashboard"))
         assert "Start next year" in response.content.decode()
 
     def test_card_hidden_when_date_not_passed(self, client, admin_user, conference):
-        PortalProfile.objects.create(user=admin_user)
         conference.conference_date = None
         conference.save()
         client.force_login(admin_user)
-        response = client.get(reverse("index"))
+        response = client.get(reverse("organizer_dashboard"))
         assert "Start next year" not in response.content.decode()
 
 
@@ -365,3 +362,58 @@ class TestConferenceCRUD:
         ]
         for url in urls:
             assert client.get(url).status_code in (302, 403)
+
+
+@pytest.mark.django_db
+class TestOrganizerDashboard:
+    def test_requires_admin(self, client, portal_user):
+        client.force_login(portal_user)
+        response = client.get(reverse("organizer_dashboard"))
+        assert response.status_code in (302, 403)
+
+    def test_renders_for_admin(self, client, admin_user, conference):
+        client.force_login(admin_user)
+        response = client.get(reverse("organizer_dashboard"))
+        assert response.status_code == 200
+        assert "Organizer dashboard" in response.content.decode()
+        assert response.context["conference"] == conference
+
+    def test_needs_attention_counts(
+        self, client, admin_user, conference, django_user_model
+    ):
+        # An unled team with a pending member.
+        team = Team.objects.create(
+            short_name="Comms", description="d", conference=conference
+        )
+        member = VolunteerProfile.objects.create(
+            user=django_user_model.objects.create_user("m1"),
+            conference=conference,
+            application_status=ApplicationStatus.PENDING,
+        )
+        member.teams.add(team)
+        # A committed-but-uninvoiced sponsor.
+        tier = SponsorshipTier.objects.create(
+            name="Gold", amount=1000, description="g", conference=conference
+        )
+        SponsorshipProfile.objects.create(
+            organization_name="Corp",
+            sponsorship_tier=tier,
+            progress_status=SponsorshipProgressStatus.APPROVED,
+            conference=conference,
+        )
+        client.force_login(admin_user)
+        response = client.get(reverse("organizer_dashboard"))
+        assert response.context["pending_reviews"] == 1
+        assert response.context["unled_teams"] == 1
+        assert response.context["awaiting_invoice"] == 1
+
+    def test_no_active_conference_renders_zeros(self, client, admin_user, conference):
+        conference.is_active = False
+        conference.save()
+        client.force_login(admin_user)
+        response = client.get(reverse("organizer_dashboard"))
+        assert response.status_code == 200
+        assert response.context["conference"] is None
+        assert response.context["pending_reviews"] == 0
+        assert response.context["unled_teams"] == 0
+        assert response.context["awaiting_invoice"] == 0


### PR DESCRIPTION
Slice 4 of the redesign: a cross-app command center for organizers.

## What changed
- **`OrganizerDashboardView`** at **`/organize/`** (admin-only): four cross-app stat cards (onboarded volunteers, sponsorship %, donations %, attendees — reusing the **same cached values** as the public Stats page), a **needs-attention** queue (pending reviews, unled teams, committed-but-uninvoiced sponsors), and **quick actions**. It's a router: every attention item / action links to an existing list view, adding no new query surface beyond a per-team pending count + one awaiting-invoice count.
- **`index()` redirects organizers** to `/organize/` (it becomes their home, and the Home link lands there); non-organizers keep the volunteer landing. To revert to "separate route only," delete the 2-line redirect.
- **Nav**: a **Dashboard** entry leads the Organize dropdown.
- **`SPONSOR_AWAITING_INVOICE_STATUS`** = committed minus `{INVOICED, PAID}`, added beside its siblings in `common.py`. No model change.

## Adaptations / fixes
- Caught and fixed a latent bug: the view called `get_stats_cached_values(conference)` unconditionally, which 500s when there's no active edition. Guarded it so the page renders **zeros**, per the spec's sanity check.
- Template djlint: dropped the container's inline `max-width`; wrapped the two dynamic-width progress bars in `djlint:off` (width is a template value, can't be a utility class).
- Updated the existing organizer-landing tests for the new redirect (the "Organizer tools" / tiers / "Start next year" content now lives on the dashboard).

## Tests
- index redirects organizers / not non-organizers; dashboard requires admin; stat + needs-attention context (with data); renders zeros with no active edition.
- **508 pass, 100% coverage**; black/isort/flake8/djlint clean; no schema change.

Refs #321