### PR TITLE
Sponsor list: needs-attention panel + one-click status filters

### DIFF
--- a/sponsorship/templates/sponsorship/sponsorshipprofile_list.html
+++ b/sponsorship/templates/sponsorship/sponsorshipprofile_list.html
@@ -28,6 +28,53 @@
             {% endfor %}
         </div>
     {% endif %}
+    {% if can_manage_sponsorship %}
+        <h2 class="h6 text-secondary mb-2">
+            {% trans "Needs attention" %}
+        </h2>
+        {% if attention_unsigned or attention_awaiting_invoice or attention_unpaid %}
+            <div class="list-group mb-3">
+                {% if attention_unsigned %}
+                    <a href="{% querystring progress_status=status_agreement_sent %}"
+                       class="list-group-item list-group-item-action list-group-item-warning d-flex align-items-center">
+                        <i class="fa-solid fa-file-signature fa-fw me-3"></i>
+                        <span class="flex-grow-1">{% blocktranslate count counter=attention_unsigned %}{{ counter }} agreement awaiting signature{% plural %}{{ counter }} agreements awaiting signature{% endblocktranslate %}</span>
+                        <i class="fa-solid fa-chevron-right"></i>
+                    </a>
+                {% endif %}
+                {% if attention_awaiting_invoice %}
+                    <a href="{% querystring progress_status=status_agreement_signed %}"
+                       class="list-group-item list-group-item-action list-group-item-warning d-flex align-items-center">
+                        <i class="fa-solid fa-file-invoice fa-fw me-3"></i>
+                        <span class="flex-grow-1">{% blocktranslate count counter=attention_awaiting_invoice %}{{ counter }} signed sponsor awaiting invoice{% plural %}{{ counter }} signed sponsors awaiting invoice{% endblocktranslate %}</span>
+                        <i class="fa-solid fa-chevron-right"></i>
+                    </a>
+                {% endif %}
+                {% if attention_unpaid %}
+                    <a href="{% querystring progress_status=status_invoiced %}"
+                       class="list-group-item list-group-item-action list-group-item-warning d-flex align-items-center">
+                        <i class="fa-solid fa-money-bill-wave fa-fw me-3"></i>
+                        <span class="flex-grow-1">{% blocktranslate count counter=attention_unpaid %}{{ counter }} invoiced sponsor not yet paid{% plural %}{{ counter }} invoiced sponsors not yet paid{% endblocktranslate %}</span>
+                        <i class="fa-solid fa-chevron-right"></i>
+                    </a>
+                {% endif %}
+            </div>
+        {% else %}
+            <div class="alert alert-light border mb-3">
+                <i class="fa-solid fa-circle-check text-success"></i> {% trans "No sponsors need attention right now." %}
+            </div>
+        {% endif %}
+        <div class="mb-3 d-flex flex-wrap gap-1"
+             role="group"
+             aria-label="Filter by status">
+            <a href="{% querystring progress_status=None %}"
+               class="btn btn-sm {% if not selected_status %}btn-secondary{% else %}btn-outline-secondary{% endif %}">{% trans "All" %}</a>
+            {% for value, label in status_choices %}
+                <a href="{% querystring progress_status=value %}"
+                   class="btn btn-sm {% if selected_status == value|stringformat:'s' %}btn-secondary{% else %}btn-outline-secondary{% endif %}">{{ label }}</a>
+            {% endfor %}
+        </div>
+    {% endif %}
     {% if filter %}
         <form action="" method="get" class="form">
             <input type="hidden" name="conference" value="{{ selected_conference.pk }}">

--- a/sponsorship/views.py
+++ b/sponsorship/views.py
@@ -318,6 +318,29 @@ class SponsorshipProfileList(CanViewSponsorship, SingleTableMixin, FilterView):
         )
         context["conferences"] = self.viewable_conferences()
         context["selected_conference"] = selected_conference
+
+        # One-click status filtering: chips link to ?progress_status=<value>.
+        context["status_choices"] = SponsorshipProgressStatus.choices
+        context["selected_status"] = self.request.GET.get("progress_status", "")
+
+        # Needs-attention buckets for managers: each is a single status that
+        # signals an action is owed, and links to the list filtered to it.
+        if self.request.user.is_superuser or self.request.user.is_staff:
+            base = SponsorshipProfile.objects.filter(conference=selected_conference)
+            context["status_agreement_sent"] = SponsorshipProgressStatus.AGREEMENT_SENT
+            context["status_agreement_signed"] = (
+                SponsorshipProgressStatus.AGREEMENT_SIGNED
+            )
+            context["status_invoiced"] = SponsorshipProgressStatus.INVOICED
+            context["attention_unsigned"] = base.filter(
+                progress_status=SponsorshipProgressStatus.AGREEMENT_SENT
+            ).count()
+            context["attention_awaiting_invoice"] = base.filter(
+                progress_status=SponsorshipProgressStatus.AGREEMENT_SIGNED
+            ).count()
+            context["attention_unpaid"] = base.filter(
+                progress_status=SponsorshipProgressStatus.INVOICED
+            ).count()
         return context
 
 

--- a/tests/sponsorship/test_views.py
+++ b/tests/sponsorship/test_views.py
@@ -925,3 +925,56 @@ class TestSponsorshipIndexRedirect:
         response = client.get(reverse("sponsorship:index"))
         assert response.status_code == 302
         assert response.url == reverse("sponsorship:sponsorship_list")
+
+
+@pytest.mark.django_db
+class TestSponsorshipNeedsAttention:
+    def _profile(self, conference, status):
+        tier = SponsorshipTier.objects.create(
+            name="T", amount=1, description="d", conference=conference
+        )
+        return SponsorshipProfile.objects.create(
+            organization_name="Org",
+            sponsorship_tier=tier,
+            progress_status=status,
+            conference=conference,
+        )
+
+    def test_attention_counts_for_manager(self, client, admin_user, conference):
+        self._profile(conference, SponsorshipProgressStatus.AGREEMENT_SENT)
+        self._profile(conference, SponsorshipProgressStatus.AGREEMENT_SIGNED)
+        self._profile(conference, SponsorshipProgressStatus.INVOICED)
+        self._profile(conference, SponsorshipProgressStatus.PAID)  # not flagged
+        client.force_login(admin_user)
+        response = client.get(reverse("sponsorship:sponsorship_list"))
+        assert response.context["attention_unsigned"] == 1
+        assert response.context["attention_awaiting_invoice"] == 1
+        assert response.context["attention_unpaid"] == 1
+        assert "Needs attention" in response.content.decode()
+
+    def test_no_attention_panel_for_read_only_viewer(
+        self, client, portal_user, conference
+    ):
+        VolunteerProfile.objects.create(
+            user=portal_user,
+            application_status=ApplicationStatus.APPROVED,
+            conference=conference,
+        )
+        client.force_login(portal_user)
+        response = client.get(reverse("sponsorship:sponsorship_list"))
+        assert "attention_unsigned" not in response.context
+        assert "Needs attention" not in response.content.decode()
+
+    def test_status_filter_chip_narrows_list(self, client, admin_user, conference):
+        self._profile(conference, SponsorshipProgressStatus.INVOICED)
+        self._profile(conference, SponsorshipProgressStatus.PAID)
+        client.force_login(admin_user)
+        url = (
+            reverse("sponsorship:sponsorship_list")
+            + f"?progress_status={SponsorshipProgressStatus.INVOICED.value}"
+        )
+        response = client.get(url)
+        assert len(response.context["table"].rows) == 1
+        assert response.context["selected_status"] == str(
+            SponsorshipProgressStatus.INVOICED.value
+        )


### PR DESCRIPTION
Easier status filtering on the sponsor list, plus a "needs attention" panel like the teams/organizer views.

## What changed (managers only)
- **Needs-attention panel** — three single-status buckets, each signalling an action is owed and linking to the list filtered to that status:
  - **Unsigned** — agreement sent, not yet signed (`AGREEMENT_SENT`)
  - **Awaiting invoice** — signed, not yet invoiced (`AGREEMENT_SIGNED`)
  - **Unpaid** — invoiced, not yet paid (`INVOICED`)

  Counts are scoped to the selected edition; a green "nothing needs attention" note shows when all three are zero.
- **Status quick-filter chips** — `All` + every status, one click to filter, the active one highlighted. Built with Django's `{% querystring %}` tag so the conference (and any other params) are preserved.

Both are gated on `can_manage_sponsorship`; read-only viewers keep the existing search/tier filter form. Each bucket maps to a single status, so every "needs attention" item is also a working filter link.

## On "overdue"
"Unpaid" covers invoiced-but-not-paid. A true time-based **overdue** (e.g. invoiced > N days ago) would need an invoice-date field on the model — happy to add that as a follow-up if you want the time dimension.

## Tests
- Attention counts correct for a manager; panel hidden from read-only viewers; a status chip narrows the list.
- **507 pass, 100% coverage**; black/isort/flake8/djlint clean; no schema change.