### PR TITLE
Fix unrounded/overflowing goal percentages on the organizer dashboard

### DIFF
--- a/portal/views.py
+++ b/portal/views.py
@@ -144,14 +144,16 @@ class OrganizerDashboardView(AdminRequiredMixin, TemplateView):
 
         # Top-line cross-app numbers (clean keys for the template).
         context["onboarded_count"] = stats.get(CACHE_KEY_VOLUNTEER_ONBOARDED_COUNT, 0)
-        context["sponsorship_goal_percent"] = stats.get(
-            CACHE_KEY_SPONSORSHIP_TOWARDS_GOAL_PERCENT, 0
-        )
+        # Goal percentages are raw divisions (can be long decimals and exceed
+        # 100% once the goal is beaten). Round for display; cap the bar at 100%.
+        sponsorship_percent = stats.get(CACHE_KEY_SPONSORSHIP_TOWARDS_GOAL_PERCENT, 0)
+        donation_percent = stats.get(CACHE_KEY_DONATION_TOWARDS_GOAL_PERCENT, 0)
+        context["sponsorship_goal_percent"] = round(sponsorship_percent)
+        context["sponsorship_bar_width"] = min(round(sponsorship_percent), 100)
         context["sponsorship_committed"] = stats.get(CACHE_KEY_SPONSORSHIP_COMMITTED, 0)
         context["sponsorship_goal"] = stats.get(SPONSORSHIP_GOAL, 0)
-        context["donation_goal_percent"] = stats.get(
-            CACHE_KEY_DONATION_TOWARDS_GOAL_PERCENT, 0
-        )
+        context["donation_goal_percent"] = round(donation_percent)
+        context["donation_bar_width"] = min(round(donation_percent), 100)
         context["donations_total"] = stats.get(CACHE_KEY_DONATIONS_TOTAL_AMOUNT, 0)
         context["donation_goal"] = conference.donation_goal if conference else 0
         context["attendee_count"] = stats.get(CACHE_KEY_ATTENDEE_COUNT, 0)

--- a/templates/portal/organizer_dashboard.html
+++ b/templates/portal/organizer_dashboard.html
@@ -47,7 +47,7 @@
                         </div>
                         {# djlint:off #}
                         <div class="progress mt-2" role="progressbar" style="height: 5px;">
-                            <div class="progress-bar" style="width: {{ sponsorship_goal_percent }}%"></div>
+                            <div class="progress-bar" style="width: {{ sponsorship_bar_width }}%"></div>
                         </div>
                         {# djlint:on #}
                     </div>
@@ -67,7 +67,7 @@
                         </div>
                         {# djlint:off #}
                         <div class="progress mt-2" role="progressbar" style="height: 5px;">
-                            <div class="progress-bar" style="width: {{ donation_goal_percent }}%"></div>
+                            <div class="progress-bar" style="width: {{ donation_bar_width }}%"></div>
                         </div>
                         {# djlint:on #}
                     </div>

--- a/tests/portal/test_views.py
+++ b/tests/portal/test_views.py
@@ -417,3 +417,21 @@ class TestOrganizerDashboard:
         assert response.context["pending_reviews"] == 0
         assert response.context["unled_teams"] == 0
         assert response.context["awaiting_invoice"] == 0
+
+    def test_goal_percent_rounded_and_bar_capped(self, client, admin_user, conference):
+        # A paid sponsor that beats the goal -> percent > 100 with a long decimal.
+        tier = SponsorshipTier.objects.create(
+            name="Big", amount=50000, description="d", conference=conference
+        )
+        SponsorshipProfile.objects.create(
+            organization_name="Whale",
+            sponsorship_tier=tier,
+            progress_status=SponsorshipProgressStatus.PAID,
+            conference=conference,
+        )
+        client.force_login(admin_user)
+        response = client.get(reverse("organizer_dashboard"))
+        pct = response.context["sponsorship_goal_percent"]
+        assert pct > 100  # goal exceeded
+        assert pct == int(pct)  # rounded, not a long decimal
+        assert response.context["sponsorship_bar_width"] == 100  # bar capped


### PR DESCRIPTION
## Bug
In production the organizer dashboard showed sponsorship/donation goal progress as a long decimal like **`365.3666666666666666666666667%`**, and once the goal was beaten the value exceeded 100% (so the progress bar overflowed its track).

## Cause
`CACHE_KEY_SPONSORSHIP_TOWARDS_GOAL_PERCENT` / `CACHE_KEY_DONATION_TOWARDS_GOAL_PERCENT` are raw `Decimal` divisions (`paid / goal * 100`) with no rounding or upper bound. The dashboard rendered them verbatim.

## Fix
In `OrganizerDashboardView`, **round** the percentages for display and add separate **bar-width** values capped at 100%:
- `sponsorship_goal_percent` / `donation_goal_percent` → `round(...)` (still shows the true figure, e.g. 365%).
- `sponsorship_bar_width` / `donation_bar_width` → `min(round(...), 100)` for the progress bars.

Display keeps the real percentage (useful: "we're at 365% of goal"); only the bar is clamped. No model or cache change, so the underlying stats are untouched.

## Tests
- A paid sponsor beating the goal → percent > 100, rendered as a whole number (not a long decimal), bar width capped at 100.
- **509 pass, 100% coverage**; black/isort/flake8/djlint clean.