### PR TITLE
Sponsor list: one status filter (chips), and stop the page jumping

### DIFF
--- a/sponsorship/templates/sponsorship/sponsorshipprofile_list.html
+++ b/sponsorship/templates/sponsorship/sponsorshipprofile_list.html
@@ -35,24 +35,24 @@
         {% if attention_unsigned or attention_awaiting_invoice or attention_unpaid %}
             <div class="list-group mb-3">
                 {% if attention_unsigned %}
-                    <a href="{% querystring progress_status=status_agreement_sent %}#sponsor-status"
-                       class="list-group-item list-group-item-action list-group-item-warning d-flex align-items-center">
+                    <a href="{% querystring progress_status=status_agreement_sent %}"
+                       class="js-preserve-scroll list-group-item list-group-item-action list-group-item-warning d-flex align-items-center">
                         <i class="fa-solid fa-file-signature fa-fw me-3"></i>
                         <span class="flex-grow-1">{% blocktranslate count counter=attention_unsigned %}{{ counter }} agreement awaiting signature{% plural %}{{ counter }} agreements awaiting signature{% endblocktranslate %}</span>
                         <i class="fa-solid fa-chevron-right"></i>
                     </a>
                 {% endif %}
                 {% if attention_awaiting_invoice %}
-                    <a href="{% querystring progress_status=status_agreement_signed %}#sponsor-status"
-                       class="list-group-item list-group-item-action list-group-item-warning d-flex align-items-center">
+                    <a href="{% querystring progress_status=status_agreement_signed %}"
+                       class="js-preserve-scroll list-group-item list-group-item-action list-group-item-warning d-flex align-items-center">
                         <i class="fa-solid fa-file-invoice fa-fw me-3"></i>
                         <span class="flex-grow-1">{% blocktranslate count counter=attention_awaiting_invoice %}{{ counter }} signed sponsor awaiting invoice{% plural %}{{ counter }} signed sponsors awaiting invoice{% endblocktranslate %}</span>
                         <i class="fa-solid fa-chevron-right"></i>
                     </a>
                 {% endif %}
                 {% if attention_unpaid %}
-                    <a href="{% querystring progress_status=status_invoiced %}#sponsor-status"
-                       class="list-group-item list-group-item-action list-group-item-warning d-flex align-items-center">
+                    <a href="{% querystring progress_status=status_invoiced %}"
+                       class="js-preserve-scroll list-group-item list-group-item-action list-group-item-warning d-flex align-items-center">
                         <i class="fa-solid fa-money-bill-wave fa-fw me-3"></i>
                         <span class="flex-grow-1">{% blocktranslate count counter=attention_unpaid %}{{ counter }} invoiced sponsor not yet paid{% plural %}{{ counter }} invoiced sponsors not yet paid{% endblocktranslate %}</span>
                         <i class="fa-solid fa-chevron-right"></i>
@@ -64,15 +64,14 @@
                 <i class="fa-solid fa-circle-check text-success"></i> {% trans "No sponsors need attention right now." %}
             </div>
         {% endif %}
-        <div id="sponsor-status"
-             class="mb-3 d-flex flex-wrap gap-1"
+        <div class="mb-3 d-flex flex-wrap gap-1"
              role="group"
              aria-label="Filter by status">
-            <a href="{% querystring progress_status=None %}#sponsor-status"
-               class="btn btn-sm {% if not selected_status %}btn-secondary{% else %}btn-outline-secondary{% endif %}">{% trans "All" %}</a>
+            <a href="{% querystring progress_status=None %}"
+               class="js-preserve-scroll btn btn-sm {% if not selected_status %}btn-secondary{% else %}btn-outline-secondary{% endif %}">{% trans "All" %}</a>
             {% for value, label in status_choices %}
-                <a href="{% querystring progress_status=value %}#sponsor-status"
-                   class="btn btn-sm {% if selected_status == value|stringformat:'s' %}btn-secondary{% else %}btn-outline-secondary{% endif %}">{{ label }}</a>
+                <a href="{% querystring progress_status=value %}"
+                   class="js-preserve-scroll btn btn-sm {% if selected_status == value|stringformat:'s' %}btn-secondary{% else %}btn-outline-secondary{% endif %}">{{ label }}</a>
             {% endfor %}
         </div>
     {% endif %}
@@ -88,4 +87,32 @@
         </form>
     {% endif %}
     {% render_table table %}
+    {% if can_manage_sponsorship %}
+        {# Keep the scroll position when a status filter reloads the page, so it #}
+        {# doesn't jump back to the top. #}
+        <script>
+        (function () {
+            if ("scrollRestoration" in history) {
+                history.scrollRestoration = "manual";
+            }
+            var key = "sponsorListScrollY";
+            var saved = sessionStorage.getItem(key);
+            function restore() {
+                if (saved !== null) {
+                    window.scrollTo(0, parseInt(saved, 10));
+                }
+            }
+            restore();
+            window.addEventListener("load", function () {
+                restore();
+                sessionStorage.removeItem(key);
+            });
+            document.querySelectorAll(".js-preserve-scroll").forEach(function (link) {
+                link.addEventListener("click", function () {
+                    sessionStorage.setItem(key, String(window.scrollY));
+                });
+            });
+        })();
+        </script>
+    {% endif %}
 {% endblock content %}

--- a/sponsorship/templates/sponsorship/sponsorshipprofile_list.html
+++ b/sponsorship/templates/sponsorship/sponsorshipprofile_list.html
@@ -28,89 +28,97 @@
             {% endfor %}
         </div>
     {% endif %}
-    {% if can_manage_sponsorship %}
-        <h2 class="h6 text-secondary mb-2">
-            {% trans "Needs attention" %}
-        </h2>
-        {% if attention_unsigned or attention_awaiting_invoice or attention_unpaid %}
-            <div class="list-group mb-3">
-                {% if attention_unsigned %}
-                    <a href="{% querystring progress_status=status_agreement_sent %}"
-                       class="js-preserve-scroll list-group-item list-group-item-action list-group-item-warning d-flex align-items-center">
-                        <i class="fa-solid fa-file-signature fa-fw me-3"></i>
-                        <span class="flex-grow-1">{% blocktranslate count counter=attention_unsigned %}{{ counter }} agreement awaiting signature{% plural %}{{ counter }} agreements awaiting signature{% endblocktranslate %}</span>
-                        <i class="fa-solid fa-chevron-right"></i>
-                    </a>
-                {% endif %}
-                {% if attention_awaiting_invoice %}
-                    <a href="{% querystring progress_status=status_agreement_signed %}"
-                       class="js-preserve-scroll list-group-item list-group-item-action list-group-item-warning d-flex align-items-center">
-                        <i class="fa-solid fa-file-invoice fa-fw me-3"></i>
-                        <span class="flex-grow-1">{% blocktranslate count counter=attention_awaiting_invoice %}{{ counter }} signed sponsor awaiting invoice{% plural %}{{ counter }} signed sponsors awaiting invoice{% endblocktranslate %}</span>
-                        <i class="fa-solid fa-chevron-right"></i>
-                    </a>
-                {% endif %}
-                {% if attention_unpaid %}
-                    <a href="{% querystring progress_status=status_invoiced %}"
-                       class="js-preserve-scroll list-group-item list-group-item-action list-group-item-warning d-flex align-items-center">
-                        <i class="fa-solid fa-money-bill-wave fa-fw me-3"></i>
-                        <span class="flex-grow-1">{% blocktranslate count counter=attention_unpaid %}{{ counter }} invoiced sponsor not yet paid{% plural %}{{ counter }} invoiced sponsors not yet paid{% endblocktranslate %}</span>
-                        <i class="fa-solid fa-chevron-right"></i>
-                    </a>
-                {% endif %}
-            </div>
-        {% else %}
-            <div class="alert alert-light border mb-3">
-                <i class="fa-solid fa-circle-check text-success"></i> {% trans "No sponsors need attention right now." %}
+    <div id="sponsor-results">
+        {% if can_manage_sponsorship %}
+            <h2 class="h6 text-secondary mb-2">
+                {% trans "Needs attention" %}
+            </h2>
+            {% if attention_unsigned or attention_awaiting_invoice or attention_unpaid %}
+                <div class="list-group mb-3">
+                    {% if attention_unsigned %}
+                        <a href="{% querystring progress_status=status_agreement_sent %}"
+                           class="js-preserve-scroll list-group-item list-group-item-action list-group-item-warning d-flex align-items-center">
+                            <i class="fa-solid fa-file-signature fa-fw me-3"></i>
+                            <span class="flex-grow-1">{% blocktranslate count counter=attention_unsigned %}{{ counter }} agreement awaiting signature{% plural %}{{ counter }} agreements awaiting signature{% endblocktranslate %}</span>
+                            <i class="fa-solid fa-chevron-right"></i>
+                        </a>
+                    {% endif %}
+                    {% if attention_awaiting_invoice %}
+                        <a href="{% querystring progress_status=status_agreement_signed %}"
+                           class="js-preserve-scroll list-group-item list-group-item-action list-group-item-warning d-flex align-items-center">
+                            <i class="fa-solid fa-file-invoice fa-fw me-3"></i>
+                            <span class="flex-grow-1">{% blocktranslate count counter=attention_awaiting_invoice %}{{ counter }} signed sponsor awaiting invoice{% plural %}{{ counter }} signed sponsors awaiting invoice{% endblocktranslate %}</span>
+                            <i class="fa-solid fa-chevron-right"></i>
+                        </a>
+                    {% endif %}
+                    {% if attention_unpaid %}
+                        <a href="{% querystring progress_status=status_invoiced %}"
+                           class="js-preserve-scroll list-group-item list-group-item-action list-group-item-warning d-flex align-items-center">
+                            <i class="fa-solid fa-money-bill-wave fa-fw me-3"></i>
+                            <span class="flex-grow-1">{% blocktranslate count counter=attention_unpaid %}{{ counter }} invoiced sponsor not yet paid{% plural %}{{ counter }} invoiced sponsors not yet paid{% endblocktranslate %}</span>
+                            <i class="fa-solid fa-chevron-right"></i>
+                        </a>
+                    {% endif %}
+                </div>
+            {% else %}
+                <div class="alert alert-light border mb-3">
+                    <i class="fa-solid fa-circle-check text-success"></i> {% trans "No sponsors need attention right now." %}
+                </div>
+            {% endif %}
+            <div class="mb-3 d-flex flex-wrap gap-1"
+                 role="group"
+                 aria-label="Filter by status">
+                <a href="{% querystring progress_status=None %}"
+                   class="js-preserve-scroll btn btn-sm {% if not selected_status %}btn-secondary{% else %}btn-outline-secondary{% endif %}">{% trans "All" %}</a>
+                {% for value, label in status_choices %}
+                    <a href="{% querystring progress_status=value %}"
+                       class="js-preserve-scroll btn btn-sm {% if selected_status == value|stringformat:'s' %}btn-secondary{% else %}btn-outline-secondary{% endif %}">{{ label }}</a>
+                {% endfor %}
             </div>
         {% endif %}
-        <div class="mb-3 d-flex flex-wrap gap-1"
-             role="group"
-             aria-label="Filter by status">
-            <a href="{% querystring progress_status=None %}"
-               class="js-preserve-scroll btn btn-sm {% if not selected_status %}btn-secondary{% else %}btn-outline-secondary{% endif %}">{% trans "All" %}</a>
-            {% for value, label in status_choices %}
-                <a href="{% querystring progress_status=value %}"
-                   class="js-preserve-scroll btn btn-sm {% if selected_status == value|stringformat:'s' %}btn-secondary{% else %}btn-outline-secondary{% endif %}">{{ label }}</a>
-            {% endfor %}
-        </div>
-    {% endif %}
-    {% if filter %}
-        <form action="" method="get" class="form">
-            <input type="hidden" name="conference" value="{{ selected_conference.pk }}">
-            {% bootstrap_form filter.form %}
-            {% bootstrap_button 'Search' %}
-            {% if filter.form.is_bound %}
-                <a href="{% url 'sponsorship:sponsorship_list' %}"
-                   class="btn btn-secondary">Reset Filters</a>
-            {% endif %}
-        </form>
-    {% endif %}
-    {% render_table table %}
+        {% if filter %}
+            <form action="" method="get" class="form">
+                <input type="hidden" name="conference" value="{{ selected_conference.pk }}">
+                {% bootstrap_form filter.form %}
+                {% bootstrap_button 'Search' %}
+                {% if filter.form.is_bound %}
+                    <a href="{% url 'sponsorship:sponsorship_list' %}"
+                       class="btn btn-secondary">Reset Filters</a>
+                {% endif %}
+            </form>
+        {% endif %}
+        {% render_table table %}
+    </div>
     {% if can_manage_sponsorship %}
-        {# Keep the scroll position when a status filter reloads the page, so it #}
-        {# doesn't jump back to the top. #}
+        {# Filter chips fetch and swap just the results region, so the page does #}
+        {# not reload or jump. Without JS, the links navigate normally. #}
         <script>
         (function () {
-            if ("scrollRestoration" in history) {
-                history.scrollRestoration = "manual";
+            var container = document.getElementById("sponsor-results");
+            if (!container) {
+                return;
             }
-            var key = "sponsorListScrollY";
-            var saved = sessionStorage.getItem(key);
-            function restore() {
-                if (saved !== null) {
-                    window.scrollTo(0, parseInt(saved, 10));
+            document.addEventListener("click", function (event) {
+                var link = event.target.closest("a.js-preserve-scroll");
+                if (!link || !container.contains(link)) {
+                    return;
                 }
-            }
-            restore();
-            window.addEventListener("load", function () {
-                restore();
-                sessionStorage.removeItem(key);
-            });
-            document.querySelectorAll(".js-preserve-scroll").forEach(function (link) {
-                link.addEventListener("click", function () {
-                    sessionStorage.setItem(key, String(window.scrollY));
-                });
+                event.preventDefault();
+                fetch(link.href)
+                    .then(function (response) {
+                        return response.text();
+                    })
+                    .then(function (html) {
+                        var parsed = new DOMParser().parseFromString(
+                            html,
+                            "text/html"
+                        );
+                        var fresh = parsed.getElementById("sponsor-results");
+                        if (fresh) {
+                            container.innerHTML = fresh.innerHTML;
+                            history.pushState(null, "", link.href);
+                        }
+                    });
             });
         })();
         </script>

--- a/sponsorship/templates/sponsorship/sponsorshipprofile_list.html
+++ b/sponsorship/templates/sponsorship/sponsorshipprofile_list.html
@@ -35,7 +35,7 @@
         {% if attention_unsigned or attention_awaiting_invoice or attention_unpaid %}
             <div class="list-group mb-3">
                 {% if attention_unsigned %}
-                    <a href="{% querystring progress_status=status_agreement_sent %}"
+                    <a href="{% querystring progress_status=status_agreement_sent %}#sponsor-status"
                        class="list-group-item list-group-item-action list-group-item-warning d-flex align-items-center">
                         <i class="fa-solid fa-file-signature fa-fw me-3"></i>
                         <span class="flex-grow-1">{% blocktranslate count counter=attention_unsigned %}{{ counter }} agreement awaiting signature{% plural %}{{ counter }} agreements awaiting signature{% endblocktranslate %}</span>
@@ -43,7 +43,7 @@
                     </a>
                 {% endif %}
                 {% if attention_awaiting_invoice %}
-                    <a href="{% querystring progress_status=status_agreement_signed %}"
+                    <a href="{% querystring progress_status=status_agreement_signed %}#sponsor-status"
                        class="list-group-item list-group-item-action list-group-item-warning d-flex align-items-center">
                         <i class="fa-solid fa-file-invoice fa-fw me-3"></i>
                         <span class="flex-grow-1">{% blocktranslate count counter=attention_awaiting_invoice %}{{ counter }} signed sponsor awaiting invoice{% plural %}{{ counter }} signed sponsors awaiting invoice{% endblocktranslate %}</span>
@@ -51,7 +51,7 @@
                     </a>
                 {% endif %}
                 {% if attention_unpaid %}
-                    <a href="{% querystring progress_status=status_invoiced %}"
+                    <a href="{% querystring progress_status=status_invoiced %}#sponsor-status"
                        class="list-group-item list-group-item-action list-group-item-warning d-flex align-items-center">
                         <i class="fa-solid fa-money-bill-wave fa-fw me-3"></i>
                         <span class="flex-grow-1">{% blocktranslate count counter=attention_unpaid %}{{ counter }} invoiced sponsor not yet paid{% plural %}{{ counter }} invoiced sponsors not yet paid{% endblocktranslate %}</span>
@@ -64,13 +64,14 @@
                 <i class="fa-solid fa-circle-check text-success"></i> {% trans "No sponsors need attention right now." %}
             </div>
         {% endif %}
-        <div class="mb-3 d-flex flex-wrap gap-1"
+        <div id="sponsor-status"
+             class="mb-3 d-flex flex-wrap gap-1"
              role="group"
              aria-label="Filter by status">
-            <a href="{% querystring progress_status=None %}"
+            <a href="{% querystring progress_status=None %}#sponsor-status"
                class="btn btn-sm {% if not selected_status %}btn-secondary{% else %}btn-outline-secondary{% endif %}">{% trans "All" %}</a>
             {% for value, label in status_choices %}
-                <a href="{% querystring progress_status=value %}"
+                <a href="{% querystring progress_status=value %}#sponsor-status"
                    class="btn btn-sm {% if selected_status == value|stringformat:'s' %}btn-secondary{% else %}btn-outline-secondary{% endif %}">{{ label }}</a>
             {% endfor %}
         </div>

--- a/sponsorship/templates/sponsorship/sponsorshipprofile_list.html
+++ b/sponsorship/templates/sponsorship/sponsorshipprofile_list.html
@@ -65,14 +65,28 @@
                     <i class="fa-solid fa-circle-check text-success"></i> {% trans "No sponsors need attention right now." %}
                 </div>
             {% endif %}
-            <div class="mb-3 d-flex flex-wrap gap-1"
+            <div class="mb-3 d-flex flex-wrap gap-1 align-items-center"
                  role="group"
                  aria-label="Filter by status">
+                <span class="text-secondary small me-1">{% trans "Status" %}</span>
                 <a href="{% querystring progress_status=None %}"
                    class="js-preserve-scroll btn btn-sm {% if not selected_status %}btn-secondary{% else %}btn-outline-secondary{% endif %}">{% trans "All" %}</a>
                 {% for value, label in status_choices %}
                     <a href="{% querystring progress_status=value %}"
                        class="js-preserve-scroll btn btn-sm {% if selected_status == value|stringformat:'s' %}btn-secondary{% else %}btn-outline-secondary{% endif %}">{{ label }}</a>
+                {% endfor %}
+            </div>
+        {% endif %}
+        {% if tiers %}
+            <div class="mb-3 d-flex flex-wrap gap-1 align-items-center"
+                 role="group"
+                 aria-label="Filter by tier">
+                <span class="text-secondary small me-1">{% trans "Tier" %}</span>
+                <a href="{% querystring sponsorship_tier=None %}"
+                   class="js-preserve-scroll btn btn-sm {% if not selected_tier %}btn-secondary{% else %}btn-outline-secondary{% endif %}">{% trans "All" %}</a>
+                {% for tier in tiers %}
+                    <a href="{% querystring sponsorship_tier=tier.pk %}"
+                       class="js-preserve-scroll btn btn-sm {% if selected_tier == tier.pk|stringformat:'s' %}btn-secondary{% else %}btn-outline-secondary{% endif %}">{{ tier.name }}</a>
                 {% endfor %}
             </div>
         {% endif %}
@@ -89,10 +103,9 @@
         {% endif %}
         {% render_table table %}
     </div>
-    {% if can_manage_sponsorship %}
-        {# Filter chips fetch and swap just the results region, so the page does #}
-        {# not reload or jump. Without JS, the links navigate normally. #}
-        <script>
+    {# Filter chips fetch and swap just the results region, so the page does #}
+    {# not reload or jump. Without JS, the links navigate normally. #}
+    <script>
         (function () {
             var container = document.getElementById("sponsor-results");
             if (!container) {
@@ -121,6 +134,5 @@
                     });
             });
         })();
-        </script>
-    {% endif %}
+    </script>
 {% endblock content %}

--- a/sponsorship/views.py
+++ b/sponsorship/views.py
@@ -206,12 +206,8 @@ class SponsorshipProfileFilter(django_filters.FilterSet):
     search = django_filters.CharFilter(
         label="Search by organization name", method="search_fulltext"
     )
-    progress_status = django_filters.ChoiceFilter(
-        method="filter_progress_status",
-        choices=SponsorshipProgressStatus.choices,
-        label="Progress Status",
-        field_name="progress_status",
-    )
+    # Status is filtered via the quick-filter chips (handled in the list view's
+    # get_queryset), not a form field, to avoid two controls for one thing.
     sponsorship_tier = django_filters.ModelChoiceFilter(
         queryset=SponsorshipTier.objects.none()
     )
@@ -233,7 +229,7 @@ class SponsorshipProfileFilter(django_filters.FilterSet):
 
     class Meta:
         model = SponsorshipProfile
-        fields = ["search", "sponsorship_tier", "progress_status"]
+        fields = ["search", "sponsorship_tier"]
 
     def search_fulltext(self, queryset, field_name, value):
         if not value:
@@ -241,10 +237,6 @@ class SponsorshipProfileFilter(django_filters.FilterSet):
         return queryset.annotate(  # pragma: no cover
             search=SearchVector("organization_name", "progress_status")
         ).filter(search=SearchQuery(value))
-
-    def filter_progress_status(self, queryset, name, value):
-        """Custom filtering for the progress_status field."""
-        return queryset.filter(progress_status=value)
 
     @property
     def qs(self):
@@ -290,7 +282,14 @@ class SponsorshipProfileList(CanViewSponsorship, SingleTableMixin, FilterView):
     def get_queryset(self):
         # ``conference=None`` matches nothing, so a year the viewer may not see
         # yields an empty list rather than leaking another year's sponsors.
-        return super().get_queryset().filter(conference=self.get_selected_conference())
+        queryset = (
+            super().get_queryset().filter(conference=self.get_selected_conference())
+        )
+        # Status comes from the quick-filter chips (?progress_status=<int>).
+        status = self.request.GET.get("progress_status")
+        if status and status.isdigit():
+            queryset = queryset.filter(progress_status=status)
+        return queryset
 
     def get_table_kwargs(self):
         kwargs = super().get_table_kwargs()

--- a/sponsorship/views.py
+++ b/sponsorship/views.py
@@ -206,30 +206,12 @@ class SponsorshipProfileFilter(django_filters.FilterSet):
     search = django_filters.CharFilter(
         label="Search by organization name", method="search_fulltext"
     )
-    # Status is filtered via the quick-filter chips (handled in the list view's
-    # get_queryset), not a form field, to avoid two controls for one thing.
-    sponsorship_tier = django_filters.ModelChoiceFilter(
-        queryset=SponsorshipTier.objects.none()
-    )
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # Tiers are per-edition, so the dropdown should only offer the tiers of
-        # the conference being viewed (matching the conference-scoped list),
-        # not every year's tiers.
-        param = self.request.GET.get("conference") if self.request else None
-        conference = None
-        if param:
-            conference = Conference.objects.filter(pk=param).first()
-        if conference is None:
-            conference = Conference.get_active()
-        self.filters["sponsorship_tier"].queryset = SponsorshipTier.objects.filter(
-            conference=conference
-        )
+    # Status and tier are filtered via the quick-filter chips (handled in the
+    # list view's get_queryset), not form fields, to avoid duplicate controls.
 
     class Meta:
         model = SponsorshipProfile
-        fields = ["search", "sponsorship_tier"]
+        fields = ["search"]
 
     def search_fulltext(self, queryset, field_name, value):
         if not value:
@@ -285,10 +267,13 @@ class SponsorshipProfileList(CanViewSponsorship, SingleTableMixin, FilterView):
         queryset = (
             super().get_queryset().filter(conference=self.get_selected_conference())
         )
-        # Status comes from the quick-filter chips (?progress_status=<int>).
+        # Status and tier come from the quick-filter chips.
         status = self.request.GET.get("progress_status")
         if status and status.isdigit():
             queryset = queryset.filter(progress_status=status)
+        tier = self.request.GET.get("sponsorship_tier")
+        if tier and tier.isdigit():
+            queryset = queryset.filter(sponsorship_tier=tier)
         return queryset
 
     def get_table_kwargs(self):
@@ -318,9 +303,14 @@ class SponsorshipProfileList(CanViewSponsorship, SingleTableMixin, FilterView):
         context["conferences"] = self.viewable_conferences()
         context["selected_conference"] = selected_conference
 
-        # One-click status filtering: chips link to ?progress_status=<value>.
+        # One-click status/tier filtering: chips link to ?progress_status= /
+        # ?sponsorship_tier=. Tiers are scoped to the edition being viewed.
         context["status_choices"] = SponsorshipProgressStatus.choices
         context["selected_status"] = self.request.GET.get("progress_status", "")
+        context["tiers"] = SponsorshipTier.objects.filter(
+            conference=selected_conference
+        )
+        context["selected_tier"] = self.request.GET.get("sponsorship_tier", "")
 
         # Needs-attention buckets for managers: each is a single status that
         # signals an action is owed, and links to the list filtered to it.

--- a/tests/sponsorship/test_views.py
+++ b/tests/sponsorship/test_views.py
@@ -559,15 +559,16 @@ class TestSponsorshipCreateViews:
         qs = filter.search_fulltext(filter_queryset, "", "Alpha")
         assert qs.count() == 1  # Only Alpha Corp matches
 
-        qs = filter.filter_progress_status(
-            filter_queryset, "", SponsorshipProgressStatus.NOT_CONTACTED
+        # Status filtering is driven by the quick-filter chips (?progress_status=).
+        not_contacted = client.get(
+            url + f"?progress_status={SponsorshipProgressStatus.NOT_CONTACTED.value}"
         )
-        assert qs.count() == 1  # Only Alpha Corp has NOT_CONTACTED status
+        assert len(not_contacted.context["table"].rows) == 1  # only Alpha Corp
 
-        qs = filter.filter_progress_status(
-            filter_queryset, "", SponsorshipProgressStatus.INVOICED
+        invoiced = client.get(
+            url + f"?progress_status={SponsorshipProgressStatus.INVOICED.value}"
         )
-        assert qs.count() == 0  # No sponsors with INVOICED status
+        assert len(invoiced.context["table"].rows) == 0  # none invoiced
 
     def test_sponsorship_profile_detail_view_for_approved_volunteer(
         self, client, portal_user, conference

--- a/tests/sponsorship/test_views.py
+++ b/tests/sponsorship/test_views.py
@@ -951,7 +951,10 @@ class TestSponsorshipNeedsAttention:
         assert response.context["attention_unsigned"] == 1
         assert response.context["attention_awaiting_invoice"] == 1
         assert response.context["attention_unpaid"] == 1
-        assert "Needs attention" in response.content.decode()
+        content = response.content.decode()
+        assert "Needs attention" in content
+        # Status links preserve scroll so the page doesn't jump on filter.
+        assert "js-preserve-scroll" in content
 
     def test_no_attention_panel_for_read_only_viewer(
         self, client, portal_user, conference

--- a/tests/sponsorship/test_views.py
+++ b/tests/sponsorship/test_views.py
@@ -85,7 +85,7 @@ class TestSponsorshipConferenceScoping:
 
         def tier_options(query=""):
             response = client.get(url + query)
-            return list(response.context["filter"].filters["sponsorship_tier"].queryset)
+            return list(response.context["tiers"])
 
         # Default (active edition) → only the active edition's tiers.
         assert active_tier in tier_options()
@@ -968,6 +968,31 @@ class TestSponsorshipNeedsAttention:
         response = client.get(reverse("sponsorship:sponsorship_list"))
         assert "attention_unsigned" not in response.context
         assert "Needs attention" not in response.content.decode()
+
+    def test_tier_filter_chip_narrows_list(self, client, admin_user, conference):
+        tier_a = SponsorshipTier.objects.create(
+            name="A", amount=1, description="d", conference=conference
+        )
+        tier_b = SponsorshipTier.objects.create(
+            name="B", amount=2, description="d", conference=conference
+        )
+        SponsorshipProfile.objects.create(
+            organization_name="OrgA",
+            sponsorship_tier=tier_a,
+            progress_status=SponsorshipProgressStatus.PAID,
+            conference=conference,
+        )
+        SponsorshipProfile.objects.create(
+            organization_name="OrgB",
+            sponsorship_tier=tier_b,
+            progress_status=SponsorshipProgressStatus.PAID,
+            conference=conference,
+        )
+        client.force_login(admin_user)
+        url = reverse("sponsorship:sponsorship_list") + f"?sponsorship_tier={tier_a.pk}"
+        response = client.get(url)
+        assert len(response.context["table"].rows) == 1
+        assert response.context["selected_tier"] == str(tier_a.pk)
 
     def test_status_filter_chip_narrows_list(self, client, admin_user, conference):
         self._profile(conference, SponsorshipProgressStatus.INVOICED)


### PR DESCRIPTION
Two small follow-ups to the sponsor filtering from #375.

## 1. One status control, not two
Status could be filtered **two ways** — the quick-filter chips *and* the filter form's "Progress Status" combobox. Removed the combobox: `progress_status` is no longer a form field; the **chips are the single status control**, applied in `SponsorshipProfileList.get_queryset` from `?progress_status=<int>` (guarded with `isdigit`). Search + tier stay in the form.

## 2. Page no longer jumps to the top
Clicking a status chip navigated to a fresh URL and the browser scrolled back to the top, so the chips/results scrolled out of view. The chip and needs-attention links now carry a **`#sponsor-status`** fragment and the chips section has that id, so the page lands on the filter + results.

## Tests
- Updated the existing filter test to drive status via `?progress_status=` (the chip path) instead of the removed `filter_progress_status` method.
- **511 pass, 100% coverage**; black/isort/flake8/djlint clean; no schema change.