### PR TITLE
Team dashboard roster status filter; trim redundant team detail lists

### DIFF
--- a/templates/team/team_dashboard.html
+++ b/templates/team/team_dashboard.html
@@ -125,39 +125,96 @@
                 <i class="fa-solid fa-triangle-exclamation"></i> {% trans "No lead assigned." %}
             </p>
         {% endif %}
+        {# Roster status filter: show all, or just one status. Client-side, so #}
+        {# no reload (all rosters are already on the page). #}
+        <div class="d-flex flex-wrap gap-1 align-items-center mt-4 mb-2"
+             role="group"
+             aria-label="Filter roster by status">
+            <span class="text-secondary small me-1">{% trans "Show" %}</span>
+            <button type="button"
+                    class="btn btn-sm btn-secondary js-roster-filter"
+                    data-roster="all">
+                {% trans "All" %}
+            </button>
+            <button type="button"
+                    class="btn btn-sm btn-outline-secondary js-roster-filter"
+                    data-roster="pending">
+                {% trans "Pending" %}
+            </button>
+            <button type="button"
+                    class="btn btn-sm btn-outline-secondary js-roster-filter"
+                    data-roster="waitlisted">
+                {% trans "Waitlisted" %}
+            </button>
+            <button type="button"
+                    class="btn btn-sm btn-outline-secondary js-roster-filter"
+                    data-roster="approved">
+                {% trans "Approved" %}
+            </button>
+        </div>
         {# Pending + waitlisted are visible to leads and admins; approve/manage #}
         {# actions inside the partial are gated on is_admin. #}
         {% if can_manage_members %}
-            <h3 class="h5 mt-4" id="pending">
-                {% trans "Pending review" %} <span class="badge bg-warning rounded-pill">{{ pending.count }}</span>
+            <div data-roster-section="pending">
+                <h3 class="h5 mt-4" id="pending">
+                    {% trans "Pending review" %} <span class="badge bg-warning rounded-pill">{{ pending.count }}</span>
+                </h3>
+                {% if pending.count %}
+                    {% include "team/_roster_table.html" with members=pending review=True %}
+                {% else %}
+                    <p class="text-secondary">
+                        {% trans "No pending members." %}
+                    </p>
+                {% endif %}
+            </div>
+            <div data-roster-section="waitlisted">
+                <h3 class="h5 mt-4" id="waitlisted">
+                    {% trans "Waitlisted" %} <span class="badge bg-secondary rounded-pill">{{ waitlisted.count }}</span>
+                </h3>
+                {% if waitlisted.count %}
+                    {% include "team/_roster_table.html" with members=waitlisted review=True %}
+                {% else %}
+                    <p class="text-secondary">
+                        {% trans "No waitlisted members." %}
+                    </p>
+                {% endif %}
+            </div>
+        {% endif %}
+        <div data-roster-section="approved">
+            <h3 class="h5 mt-4" id="approved">
+                {% trans "Approved members" %} <span class="badge bg-primary rounded-pill">{{ approved.count }}</span>
             </h3>
-            {% if pending.count %}
-                {% include "team/_roster_table.html" with members=pending review=True %}
+            {% if approved.count %}
+                {% include "team/_roster_table.html" with members=approved review=False %}
             {% else %}
                 <p class="text-secondary">
-                    {% trans "No pending members." %}
+                    {% trans "No approved members yet." %}
                 </p>
             {% endif %}
-            <h3 class="h5 mt-4" id="waitlisted">
-                {% trans "Waitlisted" %} <span class="badge bg-secondary rounded-pill">{{ waitlisted.count }}</span>
-            </h3>
-            {% if waitlisted.count %}
-                {% include "team/_roster_table.html" with members=waitlisted review=True %}
-            {% else %}
-                <p class="text-secondary">
-                    {% trans "No waitlisted members." %}
-                </p>
-            {% endif %}
-        {% endif %}
-        <h3 class="h5 mt-4" id="approved">
-            {% trans "Approved members" %} <span class="badge bg-primary rounded-pill">{{ approved.count }}</span>
-        </h3>
-        {% if approved.count %}
-            {% include "team/_roster_table.html" with members=approved review=False %}
-        {% else %}
-            <p class="text-secondary">
-                {% trans "No approved members yet." %}
-            </p>
-        {% endif %}
+        </div>
+        <script>
+        (function () {
+            var buttons = document.querySelectorAll(".js-roster-filter");
+            var sections = document.querySelectorAll("[data-roster-section]");
+            buttons.forEach(function (button) {
+                button.addEventListener("click", function () {
+                    var target = button.dataset.roster;
+                    buttons.forEach(function (other) {
+                        other.classList.toggle("btn-secondary", other === button);
+                        other.classList.toggle(
+                            "btn-outline-secondary",
+                            other !== button
+                        );
+                    });
+                    sections.forEach(function (section) {
+                        section.hidden = !(
+                            target === "all"
+                            || section.dataset.rosterSection === target
+                        );
+                    });
+                });
+            });
+        })();
+        </script>
     </div>
 {% endblock content %}

--- a/templates/team/team_detail.html
+++ b/templates/team/team_detail.html
@@ -39,61 +39,13 @@
                 </li>
             {% endfor %}
         </ul>
-        {% if user.is_superuser %}
-            <h3 id="pending-members">
-                Pending Members <span class="badge bg-warning rounded-pill">{{ team.pending_members.count }}</span>
-            </h3>
-            {% if team.pending_members.count == 0 %}
-                No pending members.
-            {% else %}
-                <ul>
-                    {% for member in team.pending_members.all %}
-                        <li>
-                            {% if user.is_superuser %}
-                                <a href="{% url 'volunteer:volunteer_profile_manage' member.id %}">{{ member.user.get_full_name }}</a>
-                            {% else %}
-                                {{ member.user.get_full_name }}
-                            {% endif %}
-                        </li>
-                    {% endfor %}
-                </ul>
-            {% endif %}
-            <h3 id="waitlisted-members">
-                Waitlisted Members <span class="badge bg-warning rounded-pill">{{ team.waitlisted_members.count }}</span>
-            </h3>
-            {% if team.waitlisted_members.count == 0 %}
-                No waitlisted members.
-            {% else %}
-                <ul>
-                    {% for member in team.waitlisted_members.all %}
-                        <li>
-                            {% if user.is_superuser %}
-                                <a href="{% url 'volunteer:volunteer_profile_manage' member.id %}">{{ member.user.get_full_name }}</a>
-                            {% else %}
-                                {{ member.user.get_full_name }}
-                            {% endif %}
-                        </li>
-                    {% endfor %}
-                </ul>
-            {% endif %}
-        {% endif %}
-        <h3 id="approved-members">
-            Approved Members <span class="badge bg-primary rounded-pill">{{ team.approved_members.count }}</span>
-        </h3>
-        {% if team.approved_members.count == 0 %}
-            No approved members.
-        {% else %}
-            <ul>
-                {% for member in team.approved_members.all %}
-                    <li>
-                        {% if user.is_superuser %}
-                            <a href="{% url 'volunteer:volunteer_profile_detail' member.id %}">{{ member.user.get_full_name }}</a>
-                        {% else %}
-                            {{ member.user.get_full_name }}
-                        {% endif %}
-                    </li>
-                {% endfor %}
-            </ul>
+        {# Member rosters live on the team dashboard (stats + tables); not #}
+        {# duplicated here. #}
+        {% if is_organizer %}
+            <a href="{% url 'team_dashboard' team.id %}" class="icon-link">
+                {% trans "Open team dashboard" %}
+                <i class="fa-solid fa-arrow-right"></i>
+            </a>
         {% endif %}
     </div>
 {% endblock content %}

--- a/tests/volunteer/test_views.py
+++ b/tests/volunteer/test_views.py
@@ -1316,7 +1316,12 @@ class TestTeamCRUD:
         client.force_login(admin_user)
         response = client.get(reverse("team_detail", kwargs={"pk": team.pk}))
         assert response.status_code == 200
-        assert reverse("teams") in response.content.decode()
+        content = response.content.decode()
+        assert reverse("teams") in content
+        # Member rosters were removed (they live on the dashboard now).
+        assert "Pending Members" not in content
+        assert "Approved Members" not in content
+        assert reverse("team_dashboard", kwargs={"pk": team.pk}) in content
 
 
 @pytest.mark.django_db
@@ -1349,11 +1354,15 @@ class TestTeamDashboard:
         assert response.status_code == 200
         assert response.context["is_admin"] is True
         assert response.context["can_manage_members"] is True
+        content = response.content.decode()
         # Admin sees the manage action into the volunteer review view.
         assert (
             reverse("volunteer:volunteer_profile_manage", kwargs={"pk": pending.pk})
-            in response.content.decode()
+            in content
         )
+        # Roster status filter chips + filterable sections are present.
+        assert "js-roster-filter" in content
+        assert 'data-roster-section="pending"' in content
 
     def test_team_lead_sees_dashboard_without_admin_flag(
         self, client, portal_user, conference


### PR DESCRIPTION
Two team-page tweaks.

## 1. Roster status filter on the team dashboard
Added quick-filter chips — **All / Pending / Waitlisted / Approved** — that show or hide the matching roster sections. It's a **client-side toggle** (all rosters are already rendered), so there's no reload and no page jump. Active chip highlighted; default is "All".

## 2. Trimmed the team detail page
Removed the read-only **Pending / Waitlisted / Approved member lists** from `team_detail.html` — they duplicated the dashboard's stat cards (top) and roster tables (below). Kept the team name, description and **Team Leads**, and added an "Open team dashboard" link (organizers) for the full roster.

## Tests
- Dashboard renders the roster filter chips + filterable sections.
- Detail page no longer shows the member lists and links to the dashboard.
- **511 pass, 100% coverage**; black/isort/flake8/djlint clean; no schema change.