### PR TITLE
Volunteer hub: mark applied teams as "under review" until approved

### DIFF
--- a/templates/volunteer/index.html
+++ b/templates/volunteer/index.html
@@ -104,9 +104,18 @@
             {% endif %}
             {# My teams — leads link to the dashboard (slice 1); members are view-only. #}
             <h2 class="h6 text-secondary mb-2">
-                {% trans "My teams" %}
+                {% if profile.is_approved %}
+                    {% trans "My teams" %}
+                {% else %}
+                    {% trans "Teams you applied to" %}
+                {% endif %}
             </h2>
             {% if my_teams %}
+                {% if not profile.is_approved %}
+                    <p class="small text-secondary mb-2">
+                        {% trans "These applications are still under review: you are not a confirmed team member yet." %}
+                    </p>
+                {% endif %}
                 <div class="list-group mb-4">
                     {% for team in my_teams %}
                         <div class="list-group-item d-flex align-items-center gap-3">
@@ -120,8 +129,10 @@
                                         ·
                                         {% blocktranslate count counter=team.pending_members.count %}{{ counter }} pending review{% plural %}{{ counter }} pending review{% endblocktranslate %}
                                     </small>
-                                {% else %}
+                                {% elif profile.is_approved %}
                                     <span class="badge text-bg-light border ms-1">{% trans "Member" %}</span>
+                                {% else %}
+                                    <span class="badge text-bg-warning ms-1">{% trans "Under review" %}</span>
                                 {% endif %}
                             </span>
                             {% if team.id in led_team_ids %}

--- a/tests/volunteer/test_views.py
+++ b/tests/volunteer/test_views.py
@@ -38,6 +38,38 @@ class TestVolunteer:
         assert response.context["profile"] == profile
         assert response.status_code == 200
 
+    def test_pending_applied_teams_marked_under_review(
+        self, client, portal_user, conference
+    ):
+        profile = VolunteerProfile.objects.create(
+            user=portal_user,
+            conference=conference,
+            application_status=ApplicationStatus.PENDING,
+        )
+        team = Team.objects.create(
+            short_name="Comms", description="d", conference=conference
+        )
+        profile.teams.add(team)
+        client.force_login(portal_user)
+        content = client.get(reverse("volunteer:index")).content.decode()
+        assert "Teams you applied to" in content
+        assert "Under review" in content
+
+    def test_approved_teams_shown_as_member(self, client, portal_user, conference):
+        profile = VolunteerProfile.objects.create(
+            user=portal_user,
+            conference=conference,
+            application_status=ApplicationStatus.APPROVED,
+        )
+        team = Team.objects.create(
+            short_name="Comms", description="d", conference=conference
+        )
+        profile.teams.add(team)
+        client.force_login(portal_user)
+        content = client.get(reverse("volunteer:index")).content.decode()
+        assert "Member" in content
+        assert "Under review" not in content
+
     def test_volunteer_profile_update_own_profile(
         self, client, portal_user, conference
     ):


### PR DESCRIPTION
## Problem
A volunteer who applies to multiple teams and isn't approved yet saw those teams under **"My teams"** with a **"Member"** badge — making it look like they were already on all of them. (After approval, only the confirmed teams show.)

## Fix
While the profile is **not approved**, the "My teams" section now:
- is titled **"Teams you applied to"** (instead of "My teams"),
- shows an amber **"Under review"** badge on each team (instead of "Member"),
- carries a short note: *"These applications are still under review: you are not a confirmed team member yet."*

Approved volunteers are unchanged (Member / Lead badges as before). This also lines up with the "Application under review" banner already at the top of the hub.

## Tests
- Pending volunteer with applied teams → "Teams you applied to" + "Under review".
- Approved volunteer → "Member", no "Under review".
- **514 pass, 100% coverage**; black/isort/flake8/djlint clean; no schema change.