### PR TITLE
Show Conference.banner_text as a dismissible site banner

### DIFF
--- a/templates/portal/base.html
+++ b/templates/portal/base.html
@@ -208,6 +208,36 @@
                 </div>
             </div>
         </nav>
+        {% if active_conference.banner_text %}
+            <div id="conference-banner"
+                 class="alert alert-info alert-dismissible rounded-0 text-center mb-0"
+                 role="alert"
+                 data-banner="{{ active_conference.banner_text }}">
+                {{ active_conference.banner_text }}
+                <button type="button"
+                        class="btn-close"
+                        data-bs-dismiss="alert"
+                        aria-label="Close">
+                </button>
+            </div>
+            <script>
+            (function () {
+                var banner = document.getElementById("conference-banner");
+                if (!banner) {
+                    return;
+                }
+                var key = "dismissedConferenceBanner";
+                // Keep it dismissed until the announcement text changes.
+                if (localStorage.getItem(key) === banner.dataset.banner) {
+                    banner.remove();
+                    return;
+                }
+                banner.addEventListener("closed.bs.alert", function () {
+                    localStorage.setItem(key, banner.dataset.banner);
+                });
+            })();
+            </script>
+        {% endif %}
         <div class="container my-5">
             {% block breadcrumb %}
             {% endblock breadcrumb %}

--- a/tests/portal/test_views.py
+++ b/tests/portal/test_views.py
@@ -435,3 +435,17 @@ class TestOrganizerDashboard:
         assert pct > 100  # goal exceeded
         assert pct == int(pct)  # rounded, not a long decimal
         assert response.context["sponsorship_bar_width"] == 100  # bar capped
+
+
+@pytest.mark.django_db
+class TestConferenceBanner:
+    def test_banner_shown_when_set(self, client, conference):
+        conference.banner_text = "Call for proposals is open!"
+        conference.save()
+        content = client.get(reverse("chapters")).content.decode()
+        assert 'id="conference-banner"' in content
+        assert "Call for proposals is open!" in content
+
+    def test_no_banner_when_empty(self, client, conference):
+        content = client.get(reverse("chapters")).content.decode()
+        assert 'id="conference-banner"' not in content


### PR DESCRIPTION
`Conference.banner_text` was editable in the conference form but rendered nowhere — whatever you typed had no effect.

## What changed
- `base.html` now shows the **active edition's `banner_text`** as a dismissible Bootstrap info bar just below the navbar, when set.
- **Dismissal persists** (localStorage) and re-appears only when the announcement text changes, so updating the message re-shows it to everyone.
- Auto-escaped output (organizer input), so no HTML injection.

## Tests
- Banner shows when `banner_text` is set; absent when empty.
- **517 pass, 100% coverage**; lint clean; no schema change.