### PR TITLE
Fix 500 on anonymous access to /sponsorship/list

### DIFF
--- a/sponsorship/views.py
+++ b/sponsorship/views.py
@@ -33,6 +33,11 @@ class CanViewSponsorship(UserPassesTestMixin):
 
     def viewable_conferences(self):
         user = self.request.user
+        # Anonymous users have no viewable conferences; filtering on them would
+        # try to coerce AnonymousUser to a user id and raise (a 500 instead of
+        # the login redirect).
+        if not user.is_authenticated:
+            return Conference.objects.none()
         if user.is_superuser or user.is_staff:
             return Conference.objects.all()
         return Conference.objects.filter(

--- a/tests/sponsorship/test_views.py
+++ b/tests/sponsorship/test_views.py
@@ -145,6 +145,13 @@ class TestSponsorshipConferenceScoping:
 
 @pytest.mark.django_db
 class TestSponsorshipViews:
+    def test_anonymous_redirected_to_login_not_500(self, client):
+        # Anonymous access must redirect to login, not crash filtering on
+        # AnonymousUser.
+        response = client.get(reverse("sponsorship:sponsorship_list"))
+        assert response.status_code == 302
+        assert "/accounts/login/" in response.url
+
     def test_sponsors_list_view_forbidden_if_not_approved_volunteer(
         self, client, portal_user, conference
     ):


### PR DESCRIPTION
## Bug
Visiting `/sponsorship/list` while logged out returned a **500** instead of a redirect/403:

```
TypeError: Field 'id' expected a number but got <SimpleLazyObject: AnonymousUser>
```

## Cause
`CanViewSponsorship.viewable_conferences()` runs in the mixin's `test_func` for **every** request, including anonymous ones. For a non-staff user it filters `Conference.objects.filter(volunteer_profiles__user=request.user, ...)`. When `request.user` is `AnonymousUser`, the ORM tries to coerce it to a user id and raises — before the mixin can do its login redirect.

## Fix
Return `Conference.objects.none()` for unauthenticated users. Then `test_func` is `False` and `UserPassesTestMixin` redirects anonymous users to the login page as intended. (Authenticated-but-not-approved still gets 403, unchanged.)

## Tests
- Anonymous GET → **302 to /accounts/login/**, no 500.
- **516 pass, 100% coverage**; lint clean; no schema change.