### PR TITLE
Add date + pretix fields to the start-new-year wizard

### DIFF
--- a/portal/forms.py
+++ b/portal/forms.py
@@ -48,6 +48,24 @@ class StartNewYearForm(forms.Form):
     year = forms.IntegerField(min_value=2000, label="Year")
     name = forms.CharField(max_length=100, label="Name")
     slug = forms.SlugField(label="Slug")
+    start_date = forms.DateField(
+        required=False,
+        widget=forms.DateInput(attrs={"type": "date"}, format="%Y-%m-%d"),
+        label="Start date",
+    )
+    end_date = forms.DateField(
+        required=False,
+        widget=forms.DateInput(attrs={"type": "date"}, format="%Y-%m-%d"),
+        label="End date",
+    )
+    conference_date = forms.DateField(
+        required=False,
+        widget=forms.DateInput(attrs={"type": "date"}, format="%Y-%m-%d"),
+        label="Conference date",
+    )
+    pretix_event_slug = forms.CharField(
+        required=False, max_length=100, label="Pretix event slug"
+    )
     clone_teams = forms.BooleanField(
         required=False, initial=True, label="Clone teams from the previous edition"
     )

--- a/portal/views.py
+++ b/portal/views.py
@@ -212,6 +212,10 @@ class StartNewYearView(SuperuserRequiredMixin, FormView):
         source = self._previous_edition()
 
         conference = Conference(year=data["year"], name=data["name"], slug=data["slug"])
+        conference.start_date = data.get("start_date")
+        conference.end_date = data.get("end_date")
+        conference.conference_date = data.get("conference_date")
+        conference.pretix_event_slug = data.get("pretix_event_slug") or ""
         if source and data["copy_goals"]:
             conference.sponsorship_goal = source.sponsorship_goal
             conference.donation_goal = source.donation_goal

--- a/tests/portal/test_views.py
+++ b/tests/portal/test_views.py
@@ -261,6 +261,27 @@ class TestStartNewYear:
         assert new.teams.count() == 0
         assert new.sponsorship_tiers.count() == 0
 
+    def test_creates_with_dates_and_pretix(self, client, admin_user, conference):
+        client.force_login(admin_user)
+        client.post(
+            reverse("start_new_year"),
+            {
+                "year": 2028,
+                "name": "PyLadiesCon 2028",
+                "slug": "2028",
+                "start_date": "2028-12-01",
+                "end_date": "2028-12-03",
+                "conference_date": "2028-12-02",
+                "pretix_event_slug": "2028",
+            },
+            follow=True,
+        )
+        new = Conference.objects.get(year=2028)
+        assert str(new.start_date) == "2028-12-01"
+        assert str(new.end_date) == "2028-12-03"
+        assert str(new.conference_date) == "2028-12-02"
+        assert new.pretix_event_slug == "2028"
+
     def test_duplicate_year_rejected(self, client, admin_user, conference):
         client.force_login(admin_user)
         response = client.post(


### PR DESCRIPTION
The "start a new year" wizard only captured year/name/slug. Add the new edition's **start date, end date, conference date, and pretix event slug** (all optional) so organizers can set them when creating the edition instead of editing it afterwards.

- `StartNewYearForm` gains the four fields (date inputs + a slug field); the template renders them via the existing `{% bootstrap_form %}`.
- `form_valid` sets them on the created `Conference`.

The new per-conference **URL fields** (#384) will be added here too as a follow-up once that merges.

**520 pass, 100% coverage**; lint clean; no schema change.