### PR TITLE
Add a "Start next conference" button to the conference list

### DIFF
--- a/portal/views.py
+++ b/portal/views.py
@@ -251,6 +251,11 @@ class ConferenceList(SuperuserRequiredMixin, ListView):
     template_name = "portal/conference_list.html"
     context_object_name = "conferences"
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["can_start_next_year"] = Conference.can_start_next_year()
+        return context
+
 
 class ConferenceUpdate(SuperuserRequiredMixin, UpdateView):
     model = Conference

--- a/templates/portal/conference_list.html
+++ b/templates/portal/conference_list.html
@@ -6,9 +6,16 @@
 {% endblock breadcrumb %}
 {% block content %}
     <div class="container px-4 py-3">
-        <h1 class="display-6 pb-2 border-bottom">
-            {% trans "Conferences" %}
-        </h1>
+        <div class="d-flex flex-wrap justify-content-between align-items-center pb-2 mb-3 border-bottom gap-2">
+            <h1 class="display-6 mb-0">
+                {% trans "Conferences" %}
+            </h1>
+            {% if can_start_next_year %}
+                <a href="{% url 'start_new_year' %}" class="btn btn-primary">
+                    <i class="fa-solid fa-plus"></i> {% trans "Start next conference" %}
+                </a>
+            {% endif %}
+        </div>
         <table class="table table-hover align-middle">
             <thead class="table-light">
                 <tr>

--- a/tests/portal/test_views.py
+++ b/tests/portal/test_views.py
@@ -357,6 +357,24 @@ class TestConferenceCRUD:
         assert response.status_code == 200
         assert conference in response.context["conferences"]
 
+    def test_list_shows_start_button_when_edition_over(
+        self, client, admin_user, conference
+    ):
+        conference.conference_date = "2000-01-01"  # past -> next year can start
+        conference.save()
+        client.force_login(admin_user)
+        response = client.get(reverse("conference_list"))
+        assert reverse("start_new_year") in response.content.decode()
+
+    def test_list_hides_start_button_while_edition_upcoming(
+        self, client, admin_user, conference
+    ):
+        conference.conference_date = None  # date unset -> not yet startable
+        conference.save()
+        client.force_login(admin_user)
+        response = client.get(reverse("conference_list"))
+        assert reverse("start_new_year") not in response.content.decode()
+
     def test_update_conference(self, client, admin_user, conference):
         client.force_login(admin_user)
         response = client.post(


### PR DESCRIPTION
The start-new-year wizard was only reachable from the organizer dashboard. Add the same button to the **conferences list** page, top-right (matching the "Manage sponsors / Add new sponsor" header pattern).

It only appears when `Conference.can_start_next_year()` is true, i.e. the active edition's date has passed (or there is no active edition yet), the same gate the wizard itself enforces.

**532 pass, 100% coverage**; lint clean.