### PR TITLE
Keep stats currency figures on one line

### DIFF
--- a/sponsorship/templates/sponsorship/sponsorship_stats.html
+++ b/sponsorship/templates/sponsorship/sponsorship_stats.html
@@ -20,7 +20,7 @@
                     <h5 class="card-title">
                         Sponsorship Paid
                     </h5>
-                    <h1 class="display-4 text-success">
+                    <h1 class="display-4 text-success text-nowrap">
                         {{ stats.sponsorship_paid_amount| as_currency }}
                     </h1>
                     <span class="text-muted">from {{ stats.sponsorship_paid_count }} sponsors</span>
@@ -33,7 +33,7 @@
                     <h5 class="card-title">
                         Pending Sponsorship Amount
                     </h5>
-                    <h1 class="display-4 text-warning">
+                    <h1 class="display-4 text-warning text-nowrap">
                         {{ stats.sponsorship_pending_amount | as_currency }}
                     </h1>
                     <span class="text-muted">from {{ stats.sponsorship_pending_count }} sponsors</span>
@@ -46,7 +46,7 @@
                     <h5 class="card-title">
                         Total Sponsorship Committed
                     </h5>
-                    <h1 class="display-4 text-success">
+                    <h1 class="display-4 text-success text-nowrap">
                         {{ stats.sponsorship_committed_amount| as_currency }}
                     </h1>
                 </div>
@@ -61,7 +61,7 @@
                         <h5 class="card-title">
                             Total Donations Received
                         </h5>
-                        <h1 class="display-4 text-info">
+                        <h1 class="display-4 text-info text-nowrap">
                             {{ stats.donation_breakdown.total_donations_amount | as_currency }}
                         </h1>
                         <span class="text-muted">from {{ stats.donation_breakdown.donors_count }} individual donors</span>
@@ -103,7 +103,7 @@
                     <h5 class="card-title">
                         Total Funds Raised
                     </h5>
-                    <h1 class="display-4 text-success">
+                    <h1 class="display-4 text-success text-nowrap">
                         {{ stats.total_funds_raised| as_currency }}
                     </h1>
                     <span class="text-muted">from sponsorships and donations</span>

--- a/tests/portal/test_views.py
+++ b/tests/portal/test_views.py
@@ -135,6 +135,12 @@ class TestPortalStats:
         assert "600" in content  # snapshot registrations
         assert "164" in content  # proposals_count
 
+    def test_stats_currency_figures_dont_wrap(self, client, conference):
+        # Large currency amounts (e.g. $54,805) must stay on one line.
+        content = client.get(reverse("portal_stats")).content.decode()
+        assert "Sponsorship Paid" in content  # the live stats panel rendered
+        assert "display-4 text-success text-nowrap" in content
+
     def test_stats_comparison_page_is_public(self, client, conference):
         response = client.get(reverse("portal_stats_comparison"))
         assert response.status_code == 200


### PR DESCRIPTION
On the Stats page, large currency figures (e.g. **$54,805**) wrapped mid-number inside the narrow `col-sm-3` stat cards: the last digit dropped to a second line. This was visible on **Sponsorship Paid** and **Total Sponsorship Committed**, among others.

Add Bootstrap's `text-nowrap` utility to the `display-4` currency figures (sponsorship paid, pending, committed, total donations, total funds raised) so each amount stays on a single line.

**531 pass, 100% coverage**; lint clean.