### PR TITLE
Stage A: contextual sidebar shell foundation

### DIFF
--- a/portal/static/css/portal.css
+++ b/portal/static/css/portal.css
@@ -76,3 +76,12 @@ body {
     content: " *";
     color: var(--bs-danger);
 }
+
+/* Contextual left rail (portal/base_sidebar.html): pinned alongside content on
+   desktop, an off-canvas drawer on mobile (handled by Bootstrap offcanvas-md). */
+@media (min-width: 768px) {
+    .app-sidebar {
+        position: sticky;
+        top: 1rem;
+    }
+}

--- a/templates/portal/_sidebar_item.html
+++ b/templates/portal/_sidebar_item.html
@@ -1,0 +1,21 @@
+{% comment %}
+Reusable left-rail item. Include with:
+    {% include "portal/_sidebar_item.html" with url=some_url label="Label" icon="fa-inbox" active=is_current badge=count %}
+Params:
+    url    — href (required)
+    label  — visible text (required)
+    icon   — Font Awesome class without the "fa-solid " prefix (optional)
+    active — truthy to mark the current section (optional)
+    badge  — small count/label shown on the right (optional)
+{% endcomment %}
+<a class="nav-link d-flex align-items-center{% if active %} active{% endif %}"
+   href="{{ url }}"
+   {% if active %}aria-current="page"{% endif %}>
+    {% if icon %}
+        <i class="fa-solid {{ icon }} fa-fw me-2"></i>
+    {% endif %}
+    <span class="flex-grow-1">{{ label }}</span>
+    {% if badge or badge == 0 %}
+        <span class="badge text-bg-secondary rounded-pill ms-2">{{ badge }}</span>
+    {% endif %}
+</a>

--- a/templates/portal/base.html
+++ b/templates/portal/base.html
@@ -257,8 +257,13 @@
         <div class="container my-5">
             {% block breadcrumb %}
             {% endblock breadcrumb %}
-            {% block content %}
-            {% endblock content %}
+            {# Layout slot: full-width by default. Pages with internal depth #}
+            {# extend portal/base_sidebar.html, which overrides this with a #}
+            {# two-column shell (a contextual left rail + the content). #}
+            {% block layout %}
+                {% block content %}
+                {% endblock content %}
+            {% endblock layout %}
         </div>
         <footer class="footer mt-auto py-3 bg-dark text-white">
             <div class="container d-flex align-items-center justify-content-between">

--- a/templates/portal/base_sidebar.html
+++ b/templates/portal/base_sidebar.html
@@ -1,0 +1,57 @@
+{% extends "portal/base.html" %}
+{% load i18n %}
+{# Two-column shell for apps with internal depth: a contextual left rail that #}
+{# is pinned on desktop (md+) and a slide-in drawer on mobile, plus the page #}
+{# content. The rail is always LOCAL to the app — never the global nav. #}
+{# Children fill: sidebar_title, sidebar (rail items), and content. #}
+{% block layout %}
+    <div class="row g-4">
+        {# Mobile-only toggle; the rail is static and always visible at md+. #}
+        <div class="col-12 d-md-none">
+            <button class="btn btn-outline-secondary"
+                    type="button"
+                    data-bs-toggle="offcanvas"
+                    data-bs-target="#appSidebar"
+                    aria-controls="appSidebar">
+                <i class="fa-solid fa-bars"></i>
+                {% block sidebar_toggle_label %}
+                    {% trans "Sections" %}
+                {% endblock sidebar_toggle_label %}
+            </button>
+        </div>
+        <aside class="col-md-4 col-lg-3">
+            <div class="offcanvas-md offcanvas-start app-sidebar"
+                 tabindex="-1"
+                 id="appSidebar"
+                 aria-labelledby="appSidebarLabel">
+                <div class="offcanvas-header">
+                    <h2 class="offcanvas-title h6 mb-0" id="appSidebarLabel">
+                        {% block sidebar_title %}
+                        {% endblock sidebar_title %}
+                    </h2>
+                    <button type="button"
+                            class="btn-close"
+                            data-bs-dismiss="offcanvas"
+                            data-bs-target="#appSidebar"
+                            aria-label="Close">
+                    </button>
+                </div>
+                <div class="offcanvas-body d-md-block p-0">
+                    <div class="d-none d-md-block text-uppercase text-secondary small fw-semibold mb-2">
+                        {% block sidebar_title_desktop %}
+                        {% endblock sidebar_title_desktop %}
+                    </div>
+                    <nav class="nav nav-pills flex-column gap-1"
+                         aria-label="Section navigation">
+                        {% block sidebar %}
+                        {% endblock sidebar %}
+                    </nav>
+                </div>
+            </div>
+        </aside>
+        <div class="col">
+            {% block content %}
+            {% endblock content %}
+        </div>
+    </div>
+{% endblock layout %}

--- a/tests/portal/test_sidebar_shell.py
+++ b/tests/portal/test_sidebar_shell.py
@@ -1,0 +1,62 @@
+"""Stage A: the sidebar shell foundation.
+
+The two-column rail is opt-in. Pages that only fill ``content`` (the vast
+majority) render full-width with no rail markup; pages that extend
+``portal/base_sidebar.html`` get a pinned-on-desktop / drawer-on-mobile rail.
+"""
+
+import pytest
+from django.template import engines
+
+
+def _render(template_string):
+    return engines["django"].from_string(template_string).render({})
+
+
+@pytest.mark.django_db
+class TestSidebarShell:
+    def test_plain_page_has_no_rail(self):
+        # Extending base.html and filling only content stays full-width.
+        html = _render(
+            '{% extends "portal/base.html" %}'
+            "{% block content %}Just content{% endblock %}"
+        )
+        assert "Just content" in html
+        assert 'id="appSidebar"' not in html
+        assert "offcanvas-md" not in html
+
+    def test_sidebar_page_renders_pinned_drawer_rail(self):
+        html = _render(
+            '{% extends "portal/base_sidebar.html" %}'
+            "{% block sidebar_title %}My App{% endblock %}"
+            '{% block sidebar %}<a href="/x">Item</a>{% endblock %}'
+            "{% block content %}Body here{% endblock %}"
+        )
+        # Rail present, content present.
+        assert 'id="appSidebar"' in html
+        assert "My App" in html
+        assert "Body here" in html
+        # offcanvas-md = static at md+, drawer below; the toggle drives it.
+        assert "offcanvas-md" in html
+        assert 'data-bs-toggle="offcanvas"' in html
+        assert 'data-bs-target="#appSidebar"' in html
+
+    def test_sidebar_item_include_marks_active(self):
+        html = _render(
+            '{% include "portal/_sidebar_item.html" with url="/inbox" '
+            'label="Inbox" icon="fa-inbox" active=True badge=3 %}'
+        )
+        assert 'href="/inbox"' in html
+        assert "Inbox" in html
+        assert "active" in html
+        assert 'aria-current="page"' in html
+        assert "fa-inbox" in html
+        assert "3" in html  # the badge
+
+    def test_sidebar_item_inactive_has_no_active_marker(self):
+        html = _render(
+            '{% include "portal/_sidebar_item.html" with url="/sent" '
+            'label="Sent" active=False %}'
+        )
+        assert 'href="/sent"' in html
+        assert 'aria-current="page"' not in html


### PR DESCRIPTION
First stage of the navigation/layout refactor from the staged handoff plan: the **shell**, purely additive, no app opts in yet.

### What
- `base.html`: the content block is now wrapped in `{% block layout %}` which emits nothing extra, so **every existing page renders full-width exactly as before** (byte-for-byte).
- **New `portal/base_sidebar.html`**: an intermediate template that overrides `layout` with a two-column shell, a contextual left rail that is **pinned on desktop (md+)** and a **slide-in drawer on mobile** via Bootstrap `offcanvas-md` (no custom JS). Children fill `{% block sidebar %}`, `{% block sidebar_title %}`, `{% block content %}`.
- **New `portal/_sidebar_item.html`**: the reusable rail-item include (url / label / icon / active / badge) so every app's rail looks identical.
- One small CSS rule pins the rail on desktop.

### Guardrails (from the plan)
The rail is always **local** to an app and only earns its place with ≥3 sibling sections or a master-detail relationship. Single-page screens (volunteer hub, organizer dashboard, landing) get no rail.

### Acceptance
Existing pages unchanged (full suite still green). A template test fills the block and asserts the rail + drawer markup appears; another asserts plain pages have no rail.

**542 pass, 100% coverage**; black/flake8/djlint clean.

---
Note: the plan's **Stage C (Messaging)** assumes a `messaging` app from "slice 5", which **does not exist in this repo**, so Stage C is not applicable. Remaining stages: B (Teams), D (Sponsorship), E (Account), F (public profile) will follow as separate PRs.