### PR TITLE
Stage B: Teams master-detail rail

### DIFF
--- a/portal/static/css/portal.css
+++ b/portal/static/css/portal.css
@@ -76,3 +76,12 @@ body {
     content: " *";
     color: var(--bs-danger);
 }
+
+/* Contextual left rail (portal/base_sidebar.html): pinned alongside content on
+   desktop, an off-canvas drawer on mobile (handled by Bootstrap offcanvas-md). */
+@media (min-width: 768px) {
+    .app-sidebar {
+        position: sticky;
+        top: 1rem;
+    }
+}

--- a/templates/portal/_sidebar_item.html
+++ b/templates/portal/_sidebar_item.html
@@ -1,0 +1,21 @@
+{% comment %}
+Reusable left-rail item. Include with:
+    {% include "portal/_sidebar_item.html" with url=some_url label="Label" icon="fa-inbox" active=is_current badge=count %}
+Params:
+    url    — href (required)
+    label  — visible text (required)
+    icon   — Font Awesome class without the "fa-solid " prefix (optional)
+    active — truthy to mark the current section (optional)
+    badge  — small count/label shown on the right (optional)
+{% endcomment %}
+<a class="nav-link d-flex align-items-center{% if active %} active{% endif %}"
+   href="{{ url }}"
+   {% if active %}aria-current="page"{% endif %}>
+    {% if icon %}
+        <i class="fa-solid {{ icon }} fa-fw me-2"></i>
+    {% endif %}
+    <span class="flex-grow-1">{{ label }}</span>
+    {% if badge or badge == 0 %}
+        <span class="badge text-bg-secondary rounded-pill ms-2">{{ badge }}</span>
+    {% endif %}
+</a>

--- a/templates/portal/base.html
+++ b/templates/portal/base.html
@@ -257,8 +257,13 @@
         <div class="container my-5">
             {% block breadcrumb %}
             {% endblock breadcrumb %}
-            {% block content %}
-            {% endblock content %}
+            {# Layout slot: full-width by default. Pages with internal depth #}
+            {# extend portal/base_sidebar.html, which overrides this with a #}
+            {# two-column shell (a contextual left rail + the content). #}
+            {% block layout %}
+                {% block content %}
+                {% endblock content %}
+            {% endblock layout %}
         </div>
         <footer class="footer mt-auto py-3 bg-dark text-white">
             <div class="container d-flex align-items-center justify-content-between">

--- a/templates/portal/base_sidebar.html
+++ b/templates/portal/base_sidebar.html
@@ -1,0 +1,57 @@
+{% extends "portal/base.html" %}
+{% load i18n %}
+{# Two-column shell for apps with internal depth: a contextual left rail that #}
+{# is pinned on desktop (md+) and a slide-in drawer on mobile, plus the page #}
+{# content. The rail is always LOCAL to the app — never the global nav. #}
+{# Children fill: sidebar_title, sidebar (rail items), and content. #}
+{% block layout %}
+    <div class="row g-4">
+        {# Mobile-only toggle; the rail is static and always visible at md+. #}
+        <div class="col-12 d-md-none">
+            <button class="btn btn-outline-secondary"
+                    type="button"
+                    data-bs-toggle="offcanvas"
+                    data-bs-target="#appSidebar"
+                    aria-controls="appSidebar">
+                <i class="fa-solid fa-bars"></i>
+                {% block sidebar_toggle_label %}
+                    {% trans "Sections" %}
+                {% endblock sidebar_toggle_label %}
+            </button>
+        </div>
+        <aside class="col-md-4 col-lg-3">
+            <div class="offcanvas-md offcanvas-start app-sidebar"
+                 tabindex="-1"
+                 id="appSidebar"
+                 aria-labelledby="appSidebarLabel">
+                <div class="offcanvas-header">
+                    <h2 class="offcanvas-title h6 mb-0" id="appSidebarLabel">
+                        {% block sidebar_title %}
+                        {% endblock sidebar_title %}
+                    </h2>
+                    <button type="button"
+                            class="btn-close"
+                            data-bs-dismiss="offcanvas"
+                            data-bs-target="#appSidebar"
+                            aria-label="Close">
+                    </button>
+                </div>
+                <div class="offcanvas-body d-md-block p-0">
+                    <div class="d-none d-md-block text-uppercase text-secondary small fw-semibold mb-2">
+                        {% block sidebar_title_desktop %}
+                        {% endblock sidebar_title_desktop %}
+                    </div>
+                    <nav class="nav nav-pills flex-column gap-1"
+                         aria-label="Section navigation">
+                        {% block sidebar %}
+                        {% endblock sidebar %}
+                    </nav>
+                </div>
+            </div>
+        </aside>
+        <div class="col">
+            {% block content %}
+            {% endblock content %}
+        </div>
+    </div>
+{% endblock layout %}

--- a/templates/team/_team_rail.html
+++ b/templates/team/_team_rail.html
@@ -1,0 +1,26 @@
+{% load i18n %}
+{% comment %}
+Teams rail (Stage B). Expects in context:
+    sidebar_teams           — the scoped team queryset (master list)
+    sidebar_current_team_id — id of the team being viewed, or None on the list
+    is_organizer            — capability flag (context processor)
+The "all teams" entry points organizers to the full list and leads to My teams.
+{% endcomment %}
+{% if is_organizer %}
+    {% url 'teams' as all_teams_url %}
+{% else %}
+    {% url 'my_teams' as all_teams_url %}
+{% endif %}
+{% if sidebar_current_team_id %}
+    {% include "portal/_sidebar_item.html" with url=all_teams_url label=_("All teams") icon="fa-list" %}
+{% else %}
+    {% include "portal/_sidebar_item.html" with url=all_teams_url label=_("All teams") icon="fa-list" active=True %}
+{% endif %}
+{% for team in sidebar_teams %}
+    {% url 'team_dashboard' team.id as team_url %}
+    {% if team.id == sidebar_current_team_id %}
+        {% include "portal/_sidebar_item.html" with url=team_url label=team.short_name icon="fa-users-rectangle" active=True %}
+    {% else %}
+        {% include "portal/_sidebar_item.html" with url=team_url label=team.short_name icon="fa-users-rectangle" %}
+    {% endif %}
+{% endfor %}

--- a/templates/team/index.html
+++ b/templates/team/index.html
@@ -1,14 +1,17 @@
-{% extends "portal/base.html" %}
-{% load allauth i18n %}
-{% load django_bootstrap5 %}
-{% block body %}
-{% endblock body %}
+{% extends "portal/base_sidebar.html" %}
+{% load i18n %}
 {% block breadcrumb %}
     {% trans "Teams" as bc_section %}
     {% include "portal/_breadcrumbs.html" with section=bc_section %}
 {% endblock breadcrumb %}
+{% block sidebar_title %}
+    {% trans "Teams" %}
+{% endblock sidebar_title %}
+{% block sidebar %}
+    {% include "team/_team_rail.html" %}
+{% endblock sidebar %}
 {% block content %}
-    <div class="container px-4 py-5" id="featured-3">
+    <div id="featured-3">
         <h1 class="display-5">
             {% trans "Teams" %} — {{ selected_conference.year }}
             <a class="btn btn-primary" href="{% url 'team_new' %}">{% trans "New Team" %}</a>

--- a/templates/team/team_dashboard.html
+++ b/templates/team/team_dashboard.html
@@ -1,9 +1,6 @@
-{% extends "portal/base.html" %}
-{% load allauth i18n %}
-{% load django_bootstrap5 %}
+{% extends "portal/base_sidebar.html" %}
+{% load i18n %}
 {% load portal_extras %}
-{% block body %}
-{% endblock body %}
 {% block breadcrumb %}
     {% if is_organizer %}
         {% url 'teams' as bc_url %}
@@ -14,8 +11,14 @@
     {% endif %}
     {% include "portal/_breadcrumbs.html" with section=bc_section section_url=bc_url page=team.short_name %}
 {% endblock breadcrumb %}
+{% block sidebar_title %}
+    {% trans "Teams" %}
+{% endblock sidebar_title %}
+{% block sidebar %}
+    {% include "team/_team_rail.html" %}
+{% endblock sidebar %}
 {% block content %}
-    <div class="container px-4 py-4">
+    <div>
         <h1 class="display-6 d-flex align-items-center flex-wrap gap-2">
             {{ team.short_name }}
             <span class="badge bg-secondary fs-6 align-middle">{{ team.conference.year }}</span>

--- a/tests/portal/test_sidebar_shell.py
+++ b/tests/portal/test_sidebar_shell.py
@@ -1,0 +1,62 @@
+"""Stage A: the sidebar shell foundation.
+
+The two-column rail is opt-in. Pages that only fill ``content`` (the vast
+majority) render full-width with no rail markup; pages that extend
+``portal/base_sidebar.html`` get a pinned-on-desktop / drawer-on-mobile rail.
+"""
+
+import pytest
+from django.template import engines
+
+
+def _render(template_string):
+    return engines["django"].from_string(template_string).render({})
+
+
+@pytest.mark.django_db
+class TestSidebarShell:
+    def test_plain_page_has_no_rail(self):
+        # Extending base.html and filling only content stays full-width.
+        html = _render(
+            '{% extends "portal/base.html" %}'
+            "{% block content %}Just content{% endblock %}"
+        )
+        assert "Just content" in html
+        assert 'id="appSidebar"' not in html
+        assert "offcanvas-md" not in html
+
+    def test_sidebar_page_renders_pinned_drawer_rail(self):
+        html = _render(
+            '{% extends "portal/base_sidebar.html" %}'
+            "{% block sidebar_title %}My App{% endblock %}"
+            '{% block sidebar %}<a href="/x">Item</a>{% endblock %}'
+            "{% block content %}Body here{% endblock %}"
+        )
+        # Rail present, content present.
+        assert 'id="appSidebar"' in html
+        assert "My App" in html
+        assert "Body here" in html
+        # offcanvas-md = static at md+, drawer below; the toggle drives it.
+        assert "offcanvas-md" in html
+        assert 'data-bs-toggle="offcanvas"' in html
+        assert 'data-bs-target="#appSidebar"' in html
+
+    def test_sidebar_item_include_marks_active(self):
+        html = _render(
+            '{% include "portal/_sidebar_item.html" with url="/inbox" '
+            'label="Inbox" icon="fa-inbox" active=True badge=3 %}'
+        )
+        assert 'href="/inbox"' in html
+        assert "Inbox" in html
+        assert "active" in html
+        assert 'aria-current="page"' in html
+        assert "fa-inbox" in html
+        assert "3" in html  # the badge
+
+    def test_sidebar_item_inactive_has_no_active_marker(self):
+        html = _render(
+            '{% include "portal/_sidebar_item.html" with url="/sent" '
+            'label="Sent" active=False %}'
+        )
+        assert 'href="/sent"' in html
+        assert 'aria-current="page"' not in html

--- a/tests/volunteer/test_views.py
+++ b/tests/volunteer/test_views.py
@@ -1446,6 +1446,84 @@ class TestTeamDashboard:
 
 
 @pytest.mark.django_db
+class TestTeamsRail:
+    """Stage B: the master-detail Teams rail and its scoping."""
+
+    def _profile(self, user, conference):
+        return VolunteerProfile.objects.create(
+            user=user,
+            conference=conference,
+            application_status=ApplicationStatus.APPROVED,
+        )
+
+    def test_list_rail_lists_all_teams_no_current(self, client, admin_user, conference):
+        a = Team.objects.create(
+            short_name="Alpha", description="d", conference=conference
+        )
+        b = Team.objects.create(
+            short_name="Bravo", description="d", conference=conference
+        )
+        client.force_login(admin_user)
+        response = client.get(reverse("teams"))
+        assert response.status_code == 200
+        assert response.context["sidebar_current_team_id"] is None
+        rail = list(response.context["sidebar_teams"])
+        assert a in rail and b in rail
+        content = response.content.decode()
+        assert reverse("team_dashboard", kwargs={"pk": a.pk}) in content
+        assert reverse("team_dashboard", kwargs={"pk": b.pk}) in content
+        # No current team -> the "All teams" entry is the active one.
+        assert "nav-link d-flex align-items-center active" in content
+
+    def test_list_rail_empty_without_active_conference(self, client, admin_user):
+        client.force_login(admin_user)
+        response = client.get(reverse("teams"))
+        assert response.status_code == 200
+        assert list(response.context["sidebar_teams"]) == []
+
+    def test_admin_dashboard_rail_lists_all_siblings_current_active(
+        self, client, admin_user, conference
+    ):
+        a = Team.objects.create(
+            short_name="Alpha", description="d", conference=conference
+        )
+        b = Team.objects.create(
+            short_name="Bravo", description="d", conference=conference
+        )
+        client.force_login(admin_user)
+        response = client.get(reverse("team_dashboard", kwargs={"pk": a.pk}))
+        assert response.status_code == 200
+        assert response.context["sidebar_current_team_id"] == a.id
+        rail = list(response.context["sidebar_teams"])
+        assert a in rail and b in rail  # admins see every team in the edition
+        content = response.content.decode()
+        assert reverse("team_dashboard", kwargs={"pk": b.pk}) in content  # siblings
+        assert "nav-link d-flex align-items-center active" in content  # a highlighted
+
+    def test_lead_dashboard_rail_lists_only_their_teams(
+        self, client, portal_user, conference, django_user_model
+    ):
+        led = Team.objects.create(
+            short_name="LedTeam", description="d", conference=conference
+        )
+        other = Team.objects.create(
+            short_name="OtherTeam", description="d", conference=conference
+        )
+        led.team_leads.add(self._profile(portal_user, conference))
+        other.team_leads.add(
+            self._profile(django_user_model.objects.create_user("ol"), conference)
+        )
+        client.force_login(portal_user)
+        response = client.get(reverse("team_dashboard", kwargs={"pk": led.pk}))
+        assert response.status_code == 200
+        rail = list(response.context["sidebar_teams"])
+        assert led in rail
+        assert other not in rail  # a lead never sees teams they don't lead
+        # ...and the unreachable team's name never leaks onto the page.
+        assert "OtherTeam" not in response.content.decode()
+
+
+@pytest.mark.django_db
 class TestMyTeams:
     def _lead(self, user, conference):
         profile = VolunteerProfile.objects.create(

--- a/volunteer/views.py
+++ b/volunteer/views.py
@@ -354,6 +354,21 @@ class VolunteerProfileDelete(DeleteView):
     success_url = reverse_lazy("volunteer:index")
 
 
+def sidebar_teams_for(user, conference):
+    """Teams to show in the Teams rail, scoped to what ``user`` may open.
+
+    Organizers (staff/superuser) see every team in the edition; a lead sees only
+    the teams they lead. Mirrors the scoping of the views the rail links to, so
+    it never leaks team names a lead cannot reach.
+    """
+    if conference is None:
+        return Team.objects.none()
+    teams = Team.objects.filter(conference=conference)
+    if not (user.is_superuser or user.is_staff):
+        teams = teams.filter(team_leads__user=user)
+    return teams.order_by("short_name").distinct()
+
+
 class TeamList(VolunteerAdminRequiredMixin, ListView):
     model = Team
     template_name = "team/index.html"
@@ -393,6 +408,11 @@ class TeamList(VolunteerAdminRequiredMixin, ListView):
         context["pending_total"] = sum(t.pending_members.count() for t in teams)
         context["open_count"] = sum(1 for t in teams if t.open_to_new_members)
         context["unled_count"] = sum(1 for t in teams if not t.team_leads.exists())
+
+        # Teams rail (Stage B): the master list. No current team on this page,
+        # so the rail's "All teams" entry is the active one.
+        context["sidebar_teams"] = sidebar_teams_for(self.request.user, conference)
+        context["sidebar_current_team_id"] = None
         return context
 
 
@@ -453,6 +473,11 @@ class TeamDashboardView(TeamLeadRequiredMixin, DetailView):
         context["can_manage_members"] = (
             is_admin or team.team_leads.filter(user=user).exists()
         )
+
+        # Teams rail (Stage B): sibling teams in this edition the user may open,
+        # with the current team highlighted.
+        context["sidebar_teams"] = sidebar_teams_for(user, team.conference)
+        context["sidebar_current_team_id"] = team.id
         return context
 
 


### PR DESCRIPTION
Second stage of the layout refactor. **Stacked on #391 (Stage A)** — review/merge that first; this PR's diff is against the Stage A branch.

### What
The Teams area becomes master-detail: a contextual left rail (the team list) beside the content (the selected team's dashboard). Moving between the all-teams overview and a team keeps the rail, current team highlighted.

- `sidebar_teams_for(user, conference)` scopes the rail to what the user may open: **organizers see every team in the edition; a lead sees only the teams they lead.** This mirrors the views' own access rules, so the rail never leaks a team name a lead can't reach.
- `team/index.html` and `team/team_dashboard.html` now extend `portal/base_sidebar.html` and render a shared `team/_team_rail.html` partial.

### Scoping is tested explicitly (the plan's flagged risk)
- Admin dashboard rail lists all sibling teams, current highlighted.
- **Lead dashboard rail lists only their teams; an unreachable team's name never appears on the page.**
- List rail lists all teams (no current); empty when there's no active edition.

**546 pass, 100% coverage**; black/flake8/djlint clean.