### PR TITLE
Stage D: sponsorship left rail + collapsed top-nav

### DIFF
--- a/sponsorship/templates/sponsorship/_sponsorship_rail.html
+++ b/sponsorship/templates/sponsorship/_sponsorship_rail.html
@@ -1,0 +1,25 @@
+{% load i18n %}
+{% comment %}
+Sponsorship rail (Stage D). Expects:
+    active                  — "sponsors" or "tiers" (the current section)
+    can_manage_sponsorship  — capability flag (context processor)
+Read-only viewers only reach the sponsor list, so the rail is rendered only on
+the manager layout (base_sidebar); Tiers and Add are manager-only.
+{% endcomment %}
+{% url 'sponsorship:sponsorship_list' as sponsors_url %}
+{% if active == "sponsors" %}
+    {% include "portal/_sidebar_item.html" with url=sponsors_url label=_("Sponsors") icon="fa-handshake" active=True %}
+{% else %}
+    {% include "portal/_sidebar_item.html" with url=sponsors_url label=_("Sponsors") icon="fa-handshake" %}
+{% endif %}
+{% if can_manage_sponsorship %}
+    {% url 'sponsorship:tier_list' as tiers_url %}
+    {% if active == "tiers" %}
+        {% include "portal/_sidebar_item.html" with url=tiers_url label=_("Tiers") icon="fa-layer-group" active=True %}
+    {% else %}
+        {% include "portal/_sidebar_item.html" with url=tiers_url label=_("Tiers") icon="fa-layer-group" %}
+    {% endif %}
+    <hr class="my-2">
+    {% url 'sponsorship:sponsorship_profile_new' as add_url %}
+    {% include "portal/_sidebar_item.html" with url=add_url label=_("Add sponsor") icon="fa-plus" %}
+{% endif %}

--- a/sponsorship/templates/sponsorship/sponsorship_profile_confirm_delete.html
+++ b/sponsorship/templates/sponsorship/sponsorship_profile_confirm_delete.html
@@ -1,4 +1,4 @@
-{% extends "portal/base.html" %}
+{% extends can_manage_sponsorship|yesno:"portal/base_sidebar.html,portal/base.html" %}
 {% load i18n %}
 {% block breadcrumb %}
     {% url 'sponsorship:sponsorship_list' as bc_url %}
@@ -6,6 +6,12 @@
     {% trans "Delete" as bc_page %}
     {% include "portal/_breadcrumbs.html" with section=bc_section section_url=bc_url page=bc_page %}
 {% endblock breadcrumb %}
+{% block sidebar_title %}
+    {% trans "Sponsorship" %}
+{% endblock sidebar_title %}
+{% block sidebar %}
+    {% include "sponsorship/_sponsorship_rail.html" with active="sponsors" %}
+{% endblock sidebar %}
 {% block content %}
     <div class="container px-4 py-3">
         <h1 class="display-6 pb-2 border-bottom">

--- a/sponsorship/templates/sponsorship/sponsorship_profile_detail.html
+++ b/sponsorship/templates/sponsorship/sponsorship_profile_detail.html
@@ -1,6 +1,12 @@
-{% extends "portal/base.html" %}
+{% extends can_manage_sponsorship|yesno:"portal/base_sidebar.html,portal/base.html" %}
 {% load allauth i18n %}
 {% load django_bootstrap5 %}
+{% block sidebar_title %}
+    {% trans "Sponsorship" %}
+{% endblock sidebar_title %}
+{% block sidebar %}
+    {% include "sponsorship/_sponsorship_rail.html" with active="sponsors" %}
+{% endblock sidebar %}
 {% block content %}
     <div class="container">
         <div class="row">

--- a/sponsorship/templates/sponsorship/sponsorship_profile_form.html
+++ b/sponsorship/templates/sponsorship/sponsorship_profile_form.html
@@ -1,4 +1,4 @@
-{% extends "portal/base.html" %}
+{% extends can_manage_sponsorship|yesno:"portal/base_sidebar.html,portal/base.html" %}
 {% load allauth i18n %}
 {% load django_bootstrap5 %}
 {% load static %}
@@ -15,6 +15,12 @@
     {% endif %}
     {% include "portal/_breadcrumbs.html" with section=bc_section section_url=bc_url page=bc_page %}
 {% endblock breadcrumb %}
+{% block sidebar_title %}
+    {% trans "Sponsorship" %}
+{% endblock sidebar_title %}
+{% block sidebar %}
+    {% include "sponsorship/_sponsorship_rail.html" with active="sponsors" %}
+{% endblock sidebar %}
 {% block content %}
     <main>
         <h1 class="display-5">

--- a/sponsorship/templates/sponsorship/sponsorshipprofile_list.html
+++ b/sponsorship/templates/sponsorship/sponsorshipprofile_list.html
@@ -1,4 +1,4 @@
-{% extends "portal/base.html" %}
+{% extends can_manage_sponsorship|yesno:"portal/base_sidebar.html,portal/base.html" %}
 {% load allauth i18n %}
 {% load django_bootstrap5 %}
 {% load render_table from django_tables2 %}
@@ -8,6 +8,12 @@
     {% trans "Sponsorship" as bc_section %}
     {% include "portal/_breadcrumbs.html" with section=bc_section %}
 {% endblock breadcrumb %}
+{% block sidebar_title %}
+    {% trans "Sponsorship" %}
+{% endblock sidebar_title %}
+{% block sidebar %}
+    {% include "sponsorship/_sponsorship_rail.html" with active="sponsors" %}
+{% endblock sidebar %}
 {% block content %}
     <h1 class="display-5">
         {% if request.user.is_superuser %}

--- a/sponsorship/templates/sponsorship/sponsorshiptier_confirm_delete.html
+++ b/sponsorship/templates/sponsorship/sponsorshiptier_confirm_delete.html
@@ -1,4 +1,4 @@
-{% extends "portal/base.html" %}
+{% extends can_manage_sponsorship|yesno:"portal/base_sidebar.html,portal/base.html" %}
 {% load i18n %}
 {% block breadcrumb %}
     {% url 'sponsorship:tier_list' as bc_url %}
@@ -6,6 +6,12 @@
     {% trans "Delete" as bc_page %}
     {% include "portal/_breadcrumbs.html" with section=bc_section section_url=bc_url page=bc_page %}
 {% endblock breadcrumb %}
+{% block sidebar_title %}
+    {% trans "Sponsorship" %}
+{% endblock sidebar_title %}
+{% block sidebar %}
+    {% include "sponsorship/_sponsorship_rail.html" with active="tiers" %}
+{% endblock sidebar %}
 {% block content %}
     <div class="container px-4 py-3">
         <h1 class="display-6 pb-2 border-bottom">

--- a/sponsorship/templates/sponsorship/sponsorshiptier_form.html
+++ b/sponsorship/templates/sponsorship/sponsorshiptier_form.html
@@ -1,4 +1,4 @@
-{% extends "portal/base.html" %}
+{% extends can_manage_sponsorship|yesno:"portal/base_sidebar.html,portal/base.html" %}
 {% load i18n %}
 {% load django_bootstrap5 %}
 {% block breadcrumb %}
@@ -11,6 +11,12 @@
     {% endif %}
     {% include "portal/_breadcrumbs.html" with section=bc_section section_url=bc_url page=bc_page %}
 {% endblock breadcrumb %}
+{% block sidebar_title %}
+    {% trans "Sponsorship" %}
+{% endblock sidebar_title %}
+{% block sidebar %}
+    {% include "sponsorship/_sponsorship_rail.html" with active="tiers" %}
+{% endblock sidebar %}
 {% block content %}
     <div class="container px-4 py-3">
         <h1 class="display-6 pb-2 border-bottom">

--- a/sponsorship/templates/sponsorship/sponsorshiptier_list.html
+++ b/sponsorship/templates/sponsorship/sponsorshiptier_list.html
@@ -1,4 +1,4 @@
-{% extends "portal/base.html" %}
+{% extends can_manage_sponsorship|yesno:"portal/base_sidebar.html,portal/base.html" %}
 {% load i18n %}
 {% block breadcrumb %}
     {% url 'sponsorship:sponsorship_list' as bc_url %}
@@ -6,6 +6,12 @@
     {% trans "Tiers" as bc_page %}
     {% include "portal/_breadcrumbs.html" with section=bc_section section_url=bc_url page=bc_page %}
 {% endblock breadcrumb %}
+{% block sidebar_title %}
+    {% trans "Sponsorship" %}
+{% endblock sidebar_title %}
+{% block sidebar %}
+    {% include "sponsorship/_sponsorship_rail.html" with active="tiers" %}
+{% endblock sidebar %}
 {% block content %}
     <div class="container px-4 py-3">
         <h1 class="display-5">

--- a/templates/portal/base.html
+++ b/templates/portal/base.html
@@ -88,30 +88,10 @@
                                 <a class="nav-link" href="{% url 'my_teams' %}">{% trans "My teams" %}</a>
                             </li>
                         {% endif %}
-                        {# Sponsorship: a dropdown of actions for managers, a plain #}
-                        {# link for read-only viewers, nothing for everyone else. #}
-                        {% if can_manage_sponsorship %}
-                            <li class="nav-item dropdown">
-                                <a class="nav-link dropdown-toggle"
-                                   href="#"
-                                   id="navSponsorship"
-                                   role="button"
-                                   data-bs-toggle="dropdown"
-                                   aria-expanded="false">{% trans "Sponsorship" %}</a>
-                                <ul class="dropdown-menu" aria-labelledby="navSponsorship">
-                                    <li>
-                                        <a class="dropdown-item" href="{% url 'sponsorship:sponsorship_list' %}">{% trans "All sponsors" %}</a>
-                                    </li>
-                                    <li>
-                                        <a class="dropdown-item"
-                                           href="{% url 'sponsorship:sponsorship_profile_new' %}">{% trans "Add sponsor" %}</a>
-                                    </li>
-                                    <li>
-                                        <a class="dropdown-item" href="{% url 'sponsorship:tier_list' %}">{% trans "Manage tiers" %}</a>
-                                    </li>
-                                </ul>
-                            </li>
-                        {% elif can_view_sponsorship %}
+                        {# Sponsorship: a single link for anyone who can view; #}
+                        {# managers reach Add/Tiers from the in-app left rail #}
+                        {# (Stage D) rather than a duplicate top-nav dropdown. #}
+                        {% if can_view_sponsorship %}
                             <li class="nav-item">
                                 <a class="nav-link" href="{% url 'sponsorship:sponsorship_list' %}">{% trans "Sponsorship" %}</a>
                             </li>

--- a/tests/sponsorship/test_views.py
+++ b/tests/sponsorship/test_views.py
@@ -144,6 +144,48 @@ class TestSponsorshipConferenceScoping:
 
 
 @pytest.mark.django_db
+class TestSponsorshipRail:
+    """Stage D: the sponsorship left rail and the collapsed top-nav link."""
+
+    def test_manager_sees_rail_with_tiers_and_add(self, client, admin_user, conference):
+        client.force_login(admin_user)
+        content = client.get(reverse("sponsorship:sponsorship_list")).content.decode()
+        assert 'id="appSidebar"' in content  # rail present for managers
+        assert reverse("sponsorship:tier_list") in content
+        assert reverse("sponsorship:sponsorship_profile_new") in content
+        # On the list, the "Sponsors" rail entry is the active one.
+        assert "nav-link d-flex align-items-center active" in content
+
+    def test_tier_list_highlights_tiers_section(self, client, admin_user, conference):
+        client.force_login(admin_user)
+        content = client.get(reverse("sponsorship:tier_list")).content.decode()
+        assert 'id="appSidebar"' in content
+        assert reverse("sponsorship:sponsorship_list") in content  # sibling section
+        assert "nav-link d-flex align-items-center active" in content  # Tiers active
+
+    def test_readonly_viewer_gets_no_rail(self, client, portal_user, conference):
+        # An approved volunteer can view the list but has a single destination,
+        # so no rail is rendered (full-width, as before).
+        VolunteerProfile.objects.create(
+            user=portal_user,
+            conference=conference,
+            application_status=ApplicationStatus.APPROVED,
+            discord_username="d",
+        )
+        client.force_login(portal_user)
+        content = client.get(reverse("sponsorship:sponsorship_list")).content.decode()
+        assert 'id="appSidebar"' not in content
+        assert reverse("sponsorship:tier_list") not in content
+        assert reverse("sponsorship:sponsorship_profile_new") not in content
+
+    def test_top_nav_collapses_to_single_link(self, client, admin_user, conference):
+        client.force_login(admin_user)
+        content = client.get(reverse("sponsorship:sponsorship_list")).content.decode()
+        assert 'id="navSponsorship"' not in content  # dropdown removed
+        assert "Manage tiers" not in content  # old dropdown item label gone
+
+
+@pytest.mark.django_db
 class TestSponsorshipViews:
     def test_anonymous_redirected_to_login_not_500(self, client):
         # Anonymous access must redirect to login, not crash filtering on


### PR DESCRIPTION
Layout refactor, Stage D (builds on the now-merged Stage A shell #391).

### What
Pull the sponsorship sub-destinations out of the top **"Sponsorship ▾" dropdown** into a contextual **left rail** (Sponsors / Tiers / Add sponsor), so navigation isn't duplicated.

- Top nav is now a **single "Sponsorship" link** for anyone who can view (per your call).
- The rail appears only on the **manager** layout: managers have ≥2 local sections (Sponsors + Tiers + Add), which earns a rail; **read-only viewers have a single destination and keep the full-width list** (the rail guardrail). The base template is selected per viewer with `can_manage_sponsorship|yesno:"base_sidebar,base"`, so **no view changes** were needed.
- New `sponsorship/_sponsorship_rail.html`; every sponsor/tier page renders it.

### Tests
Manager sees rail (Tiers + Add, current section highlighted); tier list highlights Tiers; **read-only viewer gets no rail**; top nav has no dropdown.

**546 pass, 100% coverage**; black/isort/flake8/djlint clean.

---
Remaining: **Stage E** (Account rail) next. **Stage C** N/A (no messaging app). **Stage F** (public profile) on hold per your decision.