### PR TITLE
Stage E: account settings rail

### DIFF
--- a/portal_account/views.py
+++ b/portal_account/views.py
@@ -27,6 +27,13 @@ class PortalProfileView(DetailView):
             return redirect("portal_account:index")
         return super(PortalProfileView, self).get(request, *args, **kwargs)
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        # Account settings rail (Stage E).
+        context["profile"] = self.object
+        context["account_active"] = "profile_view"
+        return context
+
 
 class PortalProfileCreate(CreateView):
     model = PortalProfile
@@ -43,6 +50,13 @@ class PortalProfileCreate(CreateView):
         kwargs = super(PortalProfileCreate, self).get_form_kwargs()
         kwargs.update({"user": self.request.user})
         return kwargs
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        # No profile yet, so the rail offers "Create my profile" (Stage E).
+        context["profile"] = None
+        context["account_active"] = "profile_new"
+        return context
 
 
 class PortalProfileUpdate(UpdateView):
@@ -62,6 +76,13 @@ class PortalProfileUpdate(UpdateView):
         kwargs = super(PortalProfileUpdate, self).get_form_kwargs()
         kwargs.update({"user": self.request.user})
         return kwargs
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        # Account settings rail (Stage E).
+        context["profile"] = self.object
+        context["account_active"] = "profile_edit"
+        return context
 
 
 class AccountEmailView(EmailView):

--- a/templates/portal_account/_account_rail.html
+++ b/templates/portal_account/_account_rail.html
@@ -1,0 +1,35 @@
+{% load i18n %}
+{% comment %}
+Account settings rail (Stage E). Expects:
+    profile        — the user's PortalProfile, or None
+    account_active — current section: "profile_edit" / "profile_view" / "profile_new"
+The Account-and-security entries link to the allauth manage pages, which keep
+their own layout (and their own back-link to Account).
+{% endcomment %}
+<div class="text-uppercase text-secondary small fw-semibold mb-1">
+    {% trans "Profile" %}
+</div>
+{% if profile %}
+    {% url 'portal_account:portal_profile_edit' profile.id as edit_url %}
+    {% if account_active == "profile_edit" %}
+        {% include "portal/_sidebar_item.html" with url=edit_url label=_("Edit profile") icon="fa-id-card" active=True %}
+    {% else %}
+        {% include "portal/_sidebar_item.html" with url=edit_url label=_("Edit profile") icon="fa-id-card" %}
+    {% endif %}
+    {% url 'portal_account:portal_profile_detail' profile.id as view_url %}
+    {% if account_active == "profile_view" %}
+        {% include "portal/_sidebar_item.html" with url=view_url label=_("View my profile") icon="fa-eye" active=True %}
+    {% else %}
+        {% include "portal/_sidebar_item.html" with url=view_url label=_("View my profile") icon="fa-eye" %}
+    {% endif %}
+{% else %}
+    {% url 'portal_account:portal_profile_new' as new_url %}
+    {% include "portal/_sidebar_item.html" with url=new_url label=_("Create my profile") icon="fa-id-card" active=True %}
+{% endif %}
+<div class="text-uppercase text-secondary small fw-semibold mb-1 mt-3">
+    {% trans "Account and security" %}
+</div>
+{% url 'account_email' as email_url %}
+{% include "portal/_sidebar_item.html" with url=email_url label=_("Email addresses") icon="fa-envelope" %}
+{% url 'account_change_password' as password_url %}
+{% include "portal/_sidebar_item.html" with url=password_url label=_("Password") icon="fa-lock" %}

--- a/templates/portal_account/portalprofile_detail.html
+++ b/templates/portal_account/portalprofile_detail.html
@@ -1,14 +1,18 @@
-{% extends "portal/base.html" %}
+{% extends "portal/base_sidebar.html" %}
 {% load allauth i18n %}
 {% load django_bootstrap5 %}
-{% block body %}
-{% endblock body %}
 {% block breadcrumb %}
     {% url 'portal_account:index' as bc_url %}
     {% trans "Account" as bc_section %}
     {% trans "Profile" as bc_page %}
     {% include "portal/_breadcrumbs.html" with section=bc_section section_url=bc_url page=bc_page %}
 {% endblock breadcrumb %}
+{% block sidebar_title %}
+    {% trans "Account" %}
+{% endblock sidebar_title %}
+{% block sidebar %}
+    {% include "portal_account/_account_rail.html" %}
+{% endblock sidebar %}
 {% block content %}
     <h1 class="display-5 mb-4">
         {% trans "Your Portal Profile" %}

--- a/templates/portal_account/portalprofile_form.html
+++ b/templates/portal_account/portalprofile_form.html
@@ -1,8 +1,6 @@
-{% extends "portal/base.html" %}
+{% extends "portal/base_sidebar.html" %}
 {% load allauth i18n %}
 {% load django_bootstrap5 %}
-{% block body %}
-{% endblock body %}
 {% block breadcrumb %}
     {% url 'portal_account:index' as bc_url %}
     {% trans "Account" as bc_section %}
@@ -13,6 +11,12 @@
     {% endif %}
     {% include "portal/_breadcrumbs.html" with section=bc_section section_url=bc_url page=bc_page %}
 {% endblock breadcrumb %}
+{% block sidebar_title %}
+    {% trans "Account" %}
+{% endblock sidebar_title %}
+{% block sidebar %}
+    {% include "portal_account/_account_rail.html" %}
+{% endblock sidebar %}
 {% block content %}
     <main>
         <h1 class="display-5">

--- a/tests/portal_account/test_views.py
+++ b/tests/portal_account/test_views.py
@@ -48,6 +48,50 @@ class TestAccountRedirects:
         assertRedirects(response, reverse("portal_account:index"))
 
 
+@pytest.mark.django_db
+class TestAccountRail:
+    """Stage E: the settings rail on the deep account pages."""
+
+    def test_detail_page_rail_highlights_view(self, client, portal_user):
+        profile = PortalProfile.objects.create(user=portal_user)
+        client.force_login(portal_user)
+        response = client.get(
+            reverse("portal_account:portal_profile_detail", kwargs={"pk": profile.id})
+        )
+        assert response.status_code == 200
+        assert response.context["account_active"] == "profile_view"
+        content = response.content.decode()
+        assert 'id="appSidebar"' in content  # rail present
+        assert reverse("account_email") in content  # Account-and-security group
+        assert reverse("account_change_password") in content
+        assert "nav-link d-flex align-items-center active" in content  # View active
+
+    def test_edit_page_rail_highlights_edit(self, client, portal_user):
+        profile = PortalProfile.objects.create(user=portal_user)
+        client.force_login(portal_user)
+        response = client.get(
+            reverse("portal_account:portal_profile_edit", kwargs={"pk": profile.id})
+        )
+        assert response.status_code == 200
+        assert response.context["account_active"] == "profile_edit"
+        content = response.content.decode()
+        assert 'id="appSidebar"' in content
+        assert (
+            reverse("portal_account:portal_profile_detail", kwargs={"pk": profile.id})
+            in content
+        )
+
+    def test_create_page_rail_offers_create(self, client, portal_user):
+        # No profile yet -> the rail's Profile group offers "Create my profile".
+        client.force_login(portal_user)
+        response = client.get(reverse("portal_account:portal_profile_new"))
+        assert response.status_code == 200
+        assert response.context["account_active"] == "profile_new"
+        content = response.content.decode()
+        assert 'id="appSidebar"' in content
+        assert "Create my profile" in content
+
+
 # -----------------------------------------------------------------------------------
 # Portal Profile Tests
 # -----------------------------------------------------------------------------------


### PR DESCRIPTION
Final stage of the layout refactor (builds on the merged Stage A shell #391).

### What
A contextual **settings rail** on the deep account pages (profile detail + edit/create), grouped:
- **Profile** — Edit profile / View my profile (or "Create my profile" when there's no profile yet)
- **Account and security** — Email addresses / Password

The current page is highlighted. Views pass `profile` + `account_active`; the templates extend `portal/base_sidebar.html` and render `portal_account/_account_rail.html`.

### A note on the index
The account **index stays as the hub** (a single-screen grouped menu) and gets **no rail**, matching the rail guardrail ("single-page screens get no rail"). The rail shows up on the pages you navigate *into*, so you can hop between Edit / View / Email / Password without bouncing back to the hub. The allauth email/password pages keep their own layout chain and existing back-link to Account (extending the rail there would be a separate follow-up).

**549 pass, 100% coverage**; black/isort/flake8/djlint clean.

---
This completes the layout refactor rails. **Stage C** N/A (no messaging app); **Stage F** (public profile) on hold per your decision.