### PR TITLE
Fix sidebar active state: brand colour + correct current tab

### DIFF
--- a/portal/static/css/portal.css
+++ b/portal/static/css/portal.css
@@ -85,3 +85,10 @@ body {
         top: 1rem;
     }
 }
+
+/* Bootstrap compiles the active pill colour to a literal blue, so overriding
+   --bs-primary alone never reaches it. Point the rail's active item at the
+   brand colour instead. */
+.app-sidebar .nav-pills {
+    --bs-nav-pills-link-active-bg: var(--bs-primary);
+}

--- a/sponsorship/templates/sponsorship/_sponsorship_rail.html
+++ b/sponsorship/templates/sponsorship/_sponsorship_rail.html
@@ -8,18 +8,18 @@ the manager layout (base_sidebar); Tiers and Add are manager-only.
 {% endcomment %}
 {% url 'sponsorship:sponsorship_list' as sponsors_url %}
 {% if active == "sponsors" %}
-    {% include "portal/_sidebar_item.html" with url=sponsors_url label=_("Sponsors") icon="fa-handshake" active=True %}
+    {% include "portal/_sidebar_item.html" with url=sponsors_url label=_("Sponsors") icon="fa-handshake" active=True only %}
 {% else %}
-    {% include "portal/_sidebar_item.html" with url=sponsors_url label=_("Sponsors") icon="fa-handshake" %}
+    {% include "portal/_sidebar_item.html" with url=sponsors_url label=_("Sponsors") icon="fa-handshake" only %}
 {% endif %}
 {% if can_manage_sponsorship %}
     {% url 'sponsorship:tier_list' as tiers_url %}
     {% if active == "tiers" %}
-        {% include "portal/_sidebar_item.html" with url=tiers_url label=_("Tiers") icon="fa-layer-group" active=True %}
+        {% include "portal/_sidebar_item.html" with url=tiers_url label=_("Tiers") icon="fa-layer-group" active=True only %}
     {% else %}
-        {% include "portal/_sidebar_item.html" with url=tiers_url label=_("Tiers") icon="fa-layer-group" %}
+        {% include "portal/_sidebar_item.html" with url=tiers_url label=_("Tiers") icon="fa-layer-group" only %}
     {% endif %}
     <hr class="my-2">
     {% url 'sponsorship:sponsorship_profile_new' as add_url %}
-    {% include "portal/_sidebar_item.html" with url=add_url label=_("Add sponsor") icon="fa-plus" %}
+    {% include "portal/_sidebar_item.html" with url=add_url label=_("Add sponsor") icon="fa-plus" only %}
 {% endif %}

--- a/templates/team/_team_rail.html
+++ b/templates/team/_team_rail.html
@@ -12,15 +12,15 @@ The "all teams" entry points organizers to the full list and leads to My teams.
     {% url 'my_teams' as all_teams_url %}
 {% endif %}
 {% if sidebar_current_team_id %}
-    {% include "portal/_sidebar_item.html" with url=all_teams_url label=_("All teams") icon="fa-list" %}
+    {% include "portal/_sidebar_item.html" with url=all_teams_url label=_("All teams") icon="fa-list" only %}
 {% else %}
-    {% include "portal/_sidebar_item.html" with url=all_teams_url label=_("All teams") icon="fa-list" active=True %}
+    {% include "portal/_sidebar_item.html" with url=all_teams_url label=_("All teams") icon="fa-list" active=True only %}
 {% endif %}
 {% for team in sidebar_teams %}
     {% url 'team_dashboard' team.id as team_url %}
     {% if team.id == sidebar_current_team_id %}
-        {% include "portal/_sidebar_item.html" with url=team_url label=team.short_name icon="fa-users-rectangle" active=True %}
+        {% include "portal/_sidebar_item.html" with url=team_url label=team.short_name icon="fa-users-rectangle" active=True only %}
     {% else %}
-        {% include "portal/_sidebar_item.html" with url=team_url label=team.short_name icon="fa-users-rectangle" %}
+        {% include "portal/_sidebar_item.html" with url=team_url label=team.short_name icon="fa-users-rectangle" only %}
     {% endif %}
 {% endfor %}

--- a/tests/sponsorship/test_views.py
+++ b/tests/sponsorship/test_views.py
@@ -147,21 +147,29 @@ class TestSponsorshipConferenceScoping:
 class TestSponsorshipRail:
     """Stage D: the sponsorship left rail and the collapsed top-nav link."""
 
+    def _active_href(self, content, url):
+        # The rail anchor spans lines; flatten whitespace, then check whether the
+        # active class sits on the link to `url`.
+        flat = " ".join(content.split())
+        return f'active" href="{url}"' in flat
+
     def test_manager_sees_rail_with_tiers_and_add(self, client, admin_user, conference):
         client.force_login(admin_user)
         content = client.get(reverse("sponsorship:sponsorship_list")).content.decode()
         assert 'id="appSidebar"' in content  # rail present for managers
         assert reverse("sponsorship:tier_list") in content
         assert reverse("sponsorship:sponsorship_profile_new") in content
-        # On the list, the "Sponsors" rail entry is the active one.
-        assert "nav-link d-flex align-items-center active" in content
+        # Only the current section highlights: Sponsors active, Tiers not.
+        assert self._active_href(content, reverse("sponsorship:sponsorship_list"))
+        assert not self._active_href(content, reverse("sponsorship:tier_list"))
 
     def test_tier_list_highlights_tiers_section(self, client, admin_user, conference):
         client.force_login(admin_user)
         content = client.get(reverse("sponsorship:tier_list")).content.decode()
         assert 'id="appSidebar"' in content
-        assert reverse("sponsorship:sponsorship_list") in content  # sibling section
-        assert "nav-link d-flex align-items-center active" in content  # Tiers active
+        # The highlight moves to Tiers; Sponsors is no longer active.
+        assert self._active_href(content, reverse("sponsorship:tier_list"))
+        assert not self._active_href(content, reverse("sponsorship:sponsorship_list"))
 
     def test_readonly_viewer_gets_no_rail(self, client, portal_user, conference):
         # An approved volunteer can view the list but has a single destination,


### PR DESCRIPTION
Two related sidebar bugs.

### 1. Active pill was blue, not brand
Bootstrap compiles the nav-pill active background to a **literal hex** (`#0d6efd`), so overriding `--bs-primary` in `:root` never reaches it. Point `.app-sidebar .nav-pills` at `var(--bs-primary)` so the active item uses the raspberry brand colour.

### 2. Sponsorship rail highlighted every tab at once
`{% include %}` passes the **full parent context** by default. The sponsorship rail names its section variable `active` (`with active="sponsors"`), which **collided** with the boolean `active` param of `_sidebar_item.html`. Inactive items don't pass `active`, so they inherited the truthy section string and were all marked active, the current tab never appeared to move.

Fix: make the item include **hermetic** with `{% include ... only %}`, so it can only see the vars explicitly passed to it. Applied to the team and sponsorship rails (both merged); the account rail (#394, still open) gets the same treatment on its branch.

Tests strengthened to assert **only the current section** is active (they'd fail on the old behaviour).

**550 pass, 100% coverage**; black/flake8/djlint clean.