### PR TITLE
Harden account rail item includes with only

### DIFF
--- a/templates/portal_account/_account_rail.html
+++ b/templates/portal_account/_account_rail.html
@@ -12,24 +12,24 @@ their own layout (and their own back-link to Account).
 {% if profile %}
     {% url 'portal_account:portal_profile_edit' profile.id as edit_url %}
     {% if account_active == "profile_edit" %}
-        {% include "portal/_sidebar_item.html" with url=edit_url label=_("Edit profile") icon="fa-id-card" active=True %}
+        {% include "portal/_sidebar_item.html" with url=edit_url label=_("Edit profile") icon="fa-id-card" active=True only %}
     {% else %}
-        {% include "portal/_sidebar_item.html" with url=edit_url label=_("Edit profile") icon="fa-id-card" %}
+        {% include "portal/_sidebar_item.html" with url=edit_url label=_("Edit profile") icon="fa-id-card" only %}
     {% endif %}
     {% url 'portal_account:portal_profile_detail' profile.id as view_url %}
     {% if account_active == "profile_view" %}
-        {% include "portal/_sidebar_item.html" with url=view_url label=_("View my profile") icon="fa-eye" active=True %}
+        {% include "portal/_sidebar_item.html" with url=view_url label=_("View my profile") icon="fa-eye" active=True only %}
     {% else %}
-        {% include "portal/_sidebar_item.html" with url=view_url label=_("View my profile") icon="fa-eye" %}
+        {% include "portal/_sidebar_item.html" with url=view_url label=_("View my profile") icon="fa-eye" only %}
     {% endif %}
 {% else %}
     {% url 'portal_account:portal_profile_new' as new_url %}
-    {% include "portal/_sidebar_item.html" with url=new_url label=_("Create my profile") icon="fa-id-card" active=True %}
+    {% include "portal/_sidebar_item.html" with url=new_url label=_("Create my profile") icon="fa-id-card" active=True only %}
 {% endif %}
 <div class="text-uppercase text-secondary small fw-semibold mb-1 mt-3">
     {% trans "Account and security" %}
 </div>
 {% url 'account_email' as email_url %}
-{% include "portal/_sidebar_item.html" with url=email_url label=_("Email addresses") icon="fa-envelope" %}
+{% include "portal/_sidebar_item.html" with url=email_url label=_("Email addresses") icon="fa-envelope" only %}
 {% url 'account_change_password' as password_url %}
-{% include "portal/_sidebar_item.html" with url=password_url label=_("Password") icon="fa-lock" %}
+{% include "portal/_sidebar_item.html" with url=password_url label=_("Password") icon="fa-lock" only %}


### PR DESCRIPTION
Follow-up to the sidebar active-state fix (#395). The account rail (merged in #394) renders `_sidebar_item.html` without `{% include ... only %}`, the same pattern that let a parent `active` variable leak into the sponsorship rail and highlight every tab.

The account rail uses `account_active` (not `active`), so there's **no active bug today**, this is consistency + future-proofing: make the item include hermetic so no parent-context variable can ever leak into its `active` flag. All three rails (team, sponsorship, account) now use `only`.

Account rail tests still pass; djlint clean.