### PR TITLE
Give every sponsorship page the same content width

### DIFF
--- a/portal/static/css/portal.css
+++ b/portal/static/css/portal.css
@@ -92,3 +92,11 @@ body {
 .app-sidebar .nav-pills {
     --bs-nav-pills-link-active-bg: var(--bs-primary);
 }
+
+/* Flex items default to min-width:auto, so a wide table would stretch the
+   content column past its grid share and make pages with wide vs narrow
+   content render at different widths. Let the column shrink to its share; wide
+   tables scroll inside it (wrap them in .table-responsive). */
+.app-content {
+    min-width: 0;
+}

--- a/sponsorship/templates/sponsorship/sponsorship_profile_confirm_delete.html
+++ b/sponsorship/templates/sponsorship/sponsorship_profile_confirm_delete.html
@@ -13,7 +13,7 @@
     {% include "sponsorship/_sponsorship_rail.html" with active="sponsors" %}
 {% endblock sidebar %}
 {% block content %}
-    <div class="container px-4 py-3">
+    <div class="py-3">
         <h1 class="display-6 pb-2 border-bottom">
             {% trans "Delete Sponsorship" %}
         </h1>

--- a/sponsorship/templates/sponsorship/sponsorship_profile_detail.html
+++ b/sponsorship/templates/sponsorship/sponsorship_profile_detail.html
@@ -8,7 +8,7 @@
     {% include "sponsorship/_sponsorship_rail.html" with active="sponsors" %}
 {% endblock sidebar %}
 {% block content %}
-    <div class="container">
+    <div class="py-3">
         <div class="row">
             <div class="col-12">
                 <nav aria-label="breadcrumb">

--- a/sponsorship/templates/sponsorship/sponsorshipprofile_list.html
+++ b/sponsorship/templates/sponsorship/sponsorshipprofile_list.html
@@ -107,7 +107,9 @@
                 {% endif %}
             </form>
         {% endif %}
-        {% render_table table %}
+        <div class="table-responsive">
+            {% render_table table %}
+        </div>
     </div>
     {# Filter chips fetch and swap just the results region, so the page does #}
     {# not reload or jump. Without JS, the links navigate normally. #}

--- a/sponsorship/templates/sponsorship/sponsorshiptier_confirm_delete.html
+++ b/sponsorship/templates/sponsorship/sponsorshiptier_confirm_delete.html
@@ -13,7 +13,7 @@
     {% include "sponsorship/_sponsorship_rail.html" with active="tiers" %}
 {% endblock sidebar %}
 {% block content %}
-    <div class="container px-4 py-3">
+    <div class="py-3">
         <h1 class="display-6 pb-2 border-bottom">
             {% trans "Delete Sponsorship Tier" %}
         </h1>

--- a/sponsorship/templates/sponsorship/sponsorshiptier_form.html
+++ b/sponsorship/templates/sponsorship/sponsorshiptier_form.html
@@ -18,7 +18,7 @@
     {% include "sponsorship/_sponsorship_rail.html" with active="tiers" %}
 {% endblock sidebar %}
 {% block content %}
-    <div class="container px-4 py-3">
+    <div class="py-3">
         <h1 class="display-6 pb-2 border-bottom">
             {% if object.pk %}
                 {% trans "Edit Sponsorship Tier" %}

--- a/sponsorship/templates/sponsorship/sponsorshiptier_list.html
+++ b/sponsorship/templates/sponsorship/sponsorshiptier_list.html
@@ -13,7 +13,7 @@
     {% include "sponsorship/_sponsorship_rail.html" with active="tiers" %}
 {% endblock sidebar %}
 {% block content %}
-    <div class="container px-4 py-3">
+    <div class="py-3">
         <h1 class="display-5">
             {% trans "Sponsorship Tiers" %} — {{ selected_conference.year }}
             <a class="btn btn-primary" href="{% url 'sponsorship:tier_new' %}">{% trans "New Tier" %}</a>

--- a/templates/portal/base_sidebar.html
+++ b/templates/portal/base_sidebar.html
@@ -49,7 +49,7 @@
                 </div>
             </div>
         </aside>
-        <div class="col">
+        <div class="col app-content">
             {% block content %}
             {% endblock content %}
         </div>

--- a/templates/team/index.html
+++ b/templates/team/index.html
@@ -89,63 +89,65 @@
                 {% blocktranslate count counter=unled_count %}{{ counter }} team has no lead assigned.{% plural %}{{ counter }} teams have no lead assigned.{% endblocktranslate %}
             </div>
         {% endif %}
-        <table class="table table-hover align-middle">
-            <thead class="table-light">
-                <tr>
-                    <th>
-                        {% trans "Name" %}
-                    </th>
-                    <th>
-                        {% trans "Leads" %}
-                    </th>
-                    <th>
-                        {% trans "Open" %}
-                    </th>
-                    <th>
-                        {% trans "Members" %}
-                    </th>
-                    <th>
-                    </th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for team in teams %}
+        <div class="table-responsive">
+            <table class="table table-hover align-middle">
+                <thead class="table-light">
                     <tr>
-                        <td>
-                            <a href="{% url 'team_dashboard' team.id %}">{{ team.short_name }}</a>
-                        </td>
-                        <td>
-                            {% for lead in team.team_leads.all %}
-                                <span class="badge text-bg-light border">{{ lead.user.get_full_name|default:lead.user.username }}</span>
-                            {% empty %}
-                                <span class="badge text-bg-danger">{% trans "unassigned" %}</span>
-                            {% endfor %}
-                        </td>
-                        <td>
-                            {% if team.open_to_new_members %}
-                                <span class="badge bg-success">{% trans "Open" %}</span>
-                            {% else %}
-                                <span class="badge bg-secondary">{% trans "Closed" %}</span>
-                            {% endif %}
-                        </td>
-                        <td>
-                            <span class="badge bg-primary rounded-pill" title="Approved">{{ team.approved_members.count }}</span>
-                            <span class="badge bg-warning rounded-pill" title="Pending">{{ team.pending_members.count }}</span>
-                            <span class="badge bg-secondary rounded-pill" title="Waitlisted">{{ team.waitlisted_members.count }}</span>
-                        </td>
-                        <td>
-                            <a href="{% url 'team_edit' team.id %}"
-                               class="btn btn-sm btn-outline-primary"
-                               title="Edit"
-                               aria-label="Edit"><i class="fa-solid fa-pencil"></i></a>
-                            <a href="{% url 'team_delete' team.id %}"
-                               class="btn btn-sm btn-outline-danger"
-                               title="Delete"
-                               aria-label="Delete"><i class="fa-solid fa-trash"></i></a>
-                        </td>
+                        <th>
+                            {% trans "Name" %}
+                        </th>
+                        <th>
+                            {% trans "Leads" %}
+                        </th>
+                        <th>
+                            {% trans "Open" %}
+                        </th>
+                        <th>
+                            {% trans "Members" %}
+                        </th>
+                        <th>
+                        </th>
                     </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+                </thead>
+                <tbody>
+                    {% for team in teams %}
+                        <tr>
+                            <td>
+                                <a href="{% url 'team_dashboard' team.id %}">{{ team.short_name }}</a>
+                            </td>
+                            <td>
+                                {% for lead in team.team_leads.all %}
+                                    <span class="badge text-bg-light border">{{ lead.user.get_full_name|default:lead.user.username }}</span>
+                                {% empty %}
+                                    <span class="badge text-bg-danger">{% trans "unassigned" %}</span>
+                                {% endfor %}
+                            </td>
+                            <td>
+                                {% if team.open_to_new_members %}
+                                    <span class="badge bg-success">{% trans "Open" %}</span>
+                                {% else %}
+                                    <span class="badge bg-secondary">{% trans "Closed" %}</span>
+                                {% endif %}
+                            </td>
+                            <td>
+                                <span class="badge bg-primary rounded-pill" title="Approved">{{ team.approved_members.count }}</span>
+                                <span class="badge bg-warning rounded-pill" title="Pending">{{ team.pending_members.count }}</span>
+                                <span class="badge bg-secondary rounded-pill" title="Waitlisted">{{ team.waitlisted_members.count }}</span>
+                            </td>
+                            <td>
+                                <a href="{% url 'team_edit' team.id %}"
+                                   class="btn btn-sm btn-outline-primary"
+                                   title="Edit"
+                                   aria-label="Edit"><i class="fa-solid fa-pencil"></i></a>
+                                <a href="{% url 'team_delete' team.id %}"
+                                   class="btn btn-sm btn-outline-danger"
+                                   title="Delete"
+                                   aria-label="Delete"><i class="fa-solid fa-trash"></i></a>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
     </div>
 {% endblock content %}


### PR DESCRIPTION
### Problem
Clicking between **Sponsors** and **Tiers** in the sponsorship rail made the content column jump/flicker: the two pages rendered at different widths.

### Cause
The sidebar shell (`base_sidebar.html`) already puts page content inside `.container my-5` → `.col`. But several sponsorship templates wrapped their content in **another** `.container`, which applies its own responsive max-width and padding, while the sponsor **list** did not. So the list filled the column and the tier list (and detail/delete/form) sat narrower.

### Fix
Drop the nested `.container` from the tier list / form / delete, the sponsor detail, and the sponsor delete pages, so every sponsorship page fills the content column uniformly (matching the list). No nested containers inside the grid column.

**553 pass, 100% coverage**; black/flake8/djlint clean.