### PR TITLE
Don't 500 when there is no active conference

### DIFF
--- a/portal/common.py
+++ b/portal/common.py
@@ -49,10 +49,18 @@ from volunteer.models import Team, VolunteerProfile
 
 
 def get_stats_cached_values(conference=None):
-    """Collect some stats and return them in a dictionary."""
+    """Collect some stats and return them in a dictionary.
+
+    Returns an empty dict when there is no conference to report on (e.g. no
+    active edition yet). Every stats helper keys its cache on
+    ``conference.year``, so a ``None`` conference has nothing to compute;
+    callers read stats with ``.get``/template lookups that tolerate the gap.
+    """
     if conference is None:
         conference = Conference.get_active()
     stats_dict = {}
+    if conference is None:
+        return stats_dict
 
     stats_dict.update(get_volunteer_stats_dict(conference))
 

--- a/tests/portal/test_common.py
+++ b/tests/portal/test_common.py
@@ -84,6 +84,14 @@ class TestGetStatsCachedValues:
         result = get_stats_cached_values(conference)
         assert result.get(CACHE_KEY_VOLUNTEER_SIGNUPS_COUNT) == 2
 
+    def test_get_stats_cached_values_no_active_conference(self):
+        # No active edition: every stats helper keys its cache on
+        # ``conference.year``, so with no conference there is nothing to compute.
+        # Return an empty dict instead of raising AttributeError on None.
+        Conference.objects.all().delete()  # drop the autouse fixture's edition
+        assert Conference.get_active() is None
+        assert get_stats_cached_values() == {}
+
     def test_get_sponsorship_total_counts_stats_does_not_count_not_contacted(
         self, conference
     ):

--- a/tests/portal/test_views.py
+++ b/tests/portal/test_views.py
@@ -25,6 +25,13 @@ class TestPortalIndex:
         assert "Sign up" in response.content.decode()
         assert "Login" in response.content.decode()
 
+    def test_index_survives_no_active_conference(self, client):
+        # It is valid to have no active edition; the public landing must not 500
+        # (regression: get_stats_cached_values dereferenced conference.year).
+        Conference.objects.all().delete()
+        response = client.get(reverse("index"))
+        assert response.status_code == 200
+
     def test_public_landing_sections_and_real_numbers(self, client, conference):
         response = client.get(reverse("index"))
         assert response.status_code == 200
@@ -95,6 +102,12 @@ class TestPortalStats:
         response = client.get(reverse("portal_stats"))
         assert response.status_code == 200
         assert "PyLadiesCon Stats" in response.content.decode()
+
+    def test_stats_survives_no_active_conference(self, client):
+        # No active edition must render the stats page, not 500.
+        Conference.objects.all().delete()
+        response = client.get(reverse("portal_stats"))
+        assert response.status_code == 200
 
     def test_stats_defaults_to_active_conference(self, client, conference):
         response = client.get(reverse("portal_stats"))


### PR DESCRIPTION
### Bug (Sentry)
```
AttributeError: 'NoneType' object has no attribute 'year'
  File "portal/views.py", line 61, in index
    "stats": get_stats_cached_values(),
  File "portal/common.py", line 124, in get_volunteer_signup_stat_cache
    cache_key = f"{...}_{conference.year}"
```
It's valid to have **no active conference** (e.g. between editions, or a fresh install). `get_stats_cached_values()` resolves `Conference.get_active()` → `None`, then every stats helper builds its cache key from `conference.year` and raises. This **500s the public landing page and the stats page** — visible to anonymous visitors.

### Fix
`get_stats_cached_values()` now returns an **empty dict** when there's no conference to report on. Callers already read stats through `.get(...)` (organizer dashboard) or template lookups (landing/stats), which tolerate the missing keys, so the pages render with zeros/blanks instead of crashing.

### Why tests didn't catch it
The autouse `conference` fixture seeds an active edition for every test, so "no active conference" never occurred in the suite. Added regression tests that delete it:
- `get_stats_cached_values()` returns `{}`;
- the anonymous **landing** and **stats** pages both return **200**.

**556 pass, 100% coverage**; black/flake8/djlint clean.