### PR TITLE
Handle no active conference in the dashboard and creation flows

### DIFF
--- a/sponsorship/forms.py
+++ b/sponsorship/forms.py
@@ -83,6 +83,14 @@ class SponsorshipProfileForm(forms.ModelForm):
         cleaned_data = super().clean()
         tier = cleaned_data.get("sponsorship_tier")
         conference = cleaned_data.get("conference") or Conference.get_active()
+        # The conference field defaults to the active edition; with none active
+        # and none chosen there is nothing to attach the sponsor to. Surface a
+        # form error instead of failing on the required FK at save time.
+        if conference is None:
+            self.add_error(
+                "conference",
+                "Select a conference. There is no active edition to default to.",
+            )
         # Guard the (selector vs dropdown) gap: a tier must belong to the same
         # conference the sponsorship is for.
         if tier and conference and tier.conference_id != conference.pk:

--- a/templates/portal/organizer_dashboard.html
+++ b/templates/portal/organizer_dashboard.html
@@ -93,8 +93,16 @@
         <h2 class="h6 text-secondary mb-2">
             {% trans "Needs attention" %}
         </h2>
-        {% if pending_reviews or unled_teams or awaiting_invoice %}
+        {% if not conference or pending_reviews or unled_teams or awaiting_invoice %}
             <div class="list-group mb-4">
+                {% if not conference %}
+                    <a href="{% url 'conference_list' %}"
+                       class="list-group-item list-group-item-action list-group-item-danger d-flex align-items-center">
+                        <i class="fa-solid fa-calendar-xmark fa-fw me-3"></i>
+                        <span class="flex-grow-1"><strong>{% trans "No active conference." %}</strong> {% trans "Activate a conference so the portal reports on the current year." %}</span>
+                        <i class="fa-solid fa-chevron-right"></i>
+                    </a>
+                {% endif %}
                 {% if pending_reviews %}
                     <a href="{% url 'teams' %}"
                        class="list-group-item list-group-item-action list-group-item-warning d-flex align-items-center">
@@ -144,6 +152,15 @@
                     <div class="card-body d-flex align-items-center gap-3">
                         <i class="fa-solid fa-users-rectangle fs-5 text-primary"></i>
                         <span class="text-body">{% trans "Manage teams" %}</span>
+                    </div>
+                </a>
+            </div>
+            <div class="col">
+                <a href="{% url 'sponsorship:sponsorship_list' %}"
+                   class="card h-100 text-decoration-none">
+                    <div class="card-body d-flex align-items-center gap-3">
+                        <i class="fa-solid fa-hand-holding-dollar fs-5 text-primary"></i>
+                        <span class="text-body">{% trans "Manage sponsors" %}</span>
                     </div>
                 </a>
             </div>

--- a/templates/volunteer/index.html
+++ b/templates/volunteer/index.html
@@ -33,8 +33,15 @@
                             {% trans "You get access to the tools and Discord once onboarded." %}
                         </li>
                     </ol>
-                    <a class="btn btn-primary"
-                       href="{% url 'volunteer:volunteer_profile_new' %}">{% trans "Create my volunteer profile" %}</a>
+                    {% if active_conference %}
+                        <a class="btn btn-primary"
+                           href="{% url 'volunteer:volunteer_profile_new' %}">{% trans "Create my volunteer profile" %}</a>
+                    {% else %}
+                        <p class="mb-0 text-secondary">
+                            <i class="fa-solid fa-circle-info"></i>
+                            {% trans "Volunteer sign-ups open once the next conference is active." %}
+                        </p>
+                    {% endif %}
                 </div>
             </div>
         {% else %}

--- a/tests/portal/test_views.py
+++ b/tests/portal/test_views.py
@@ -465,8 +465,12 @@ class TestOrganizerDashboard:
         client.force_login(admin_user)
         response = client.get(reverse("organizer_dashboard"))
         assert response.status_code == 200
-        assert "Organizer dashboard" in response.content.decode()
+        content = response.content.decode()
+        assert "Organizer dashboard" in content
         assert response.context["conference"] == conference
+        # Quick actions include managing the sponsor list, not just adding one.
+        assert "Manage sponsors" in content
+        assert reverse("sponsorship:sponsorship_list") in content
 
     def test_needs_attention_counts(
         self, client, admin_user, conference, django_user_model
@@ -507,6 +511,18 @@ class TestOrganizerDashboard:
         assert response.context["pending_reviews"] == 0
         assert response.context["unled_teams"] == 0
         assert response.context["awaiting_invoice"] == 0
+
+    def test_no_active_conference_flagged_in_needs_attention(
+        self, client, admin_user, conference
+    ):
+        conference.is_active = False
+        conference.save()
+        client.force_login(admin_user)
+        content = client.get(reverse("organizer_dashboard")).content.decode()
+        assert "No active conference." in content
+        assert reverse("conference_list") in content
+        # It is an attention item, not the "nothing to do" state.
+        assert "Nothing needs your attention" not in content
 
     def test_goal_percent_rounded_and_bar_capped(self, client, admin_user, conference):
         # A paid sponsor that beats the goal -> percent > 100 with a long decimal.

--- a/tests/sponsorship/test_forms.py
+++ b/tests/sponsorship/test_forms.py
@@ -1,7 +1,7 @@
 import pytest
 
 from portal.models import Conference
-from sponsorship.forms import SponsorshipProfileForm
+from sponsorship.forms import SponsorshipProfileForm, SponsorshipTierForm
 from sponsorship.models import (
     SponsorshipProfile,
     SponsorshipProgressStatus,
@@ -48,6 +48,14 @@ class TestSponsorshipProfileForm:
         assert form.is_valid()
         profile = form.save()
         assert profile.conference == past
+
+    def test_errors_when_no_conference_and_none_active(self, form_data):
+        # No conference chosen and no active edition to default to: a form
+        # error, not a 500 on the required conference FK at save time.
+        Conference.objects.all().delete()
+        form = SponsorshipProfileForm(data=form_data)
+        assert not form.is_valid()
+        assert "conference" in form.errors
 
     def test_tier_choices_scoped_to_active_conference(self, conference):
         past = Conference.objects.create(
@@ -195,3 +203,29 @@ class TestSponsorshipProfileForm:
 
         assert past_tier in tiers  # the sponsor's own edition
         assert active_tier not in tiers
+
+
+@pytest.mark.django_db
+class TestSponsorshipTierForm:
+    def test_conference_is_required(self):
+        # Tiers are conference-scoped; the form requires an explicit conference,
+        # so it never 500s on the required FK even with no active edition.
+        Conference.objects.all().delete()
+        form = SponsorshipTierForm(
+            data={"name": "Gold", "amount": "1000", "description": "d"}
+        )
+        assert not form.is_valid()
+        assert "conference" in form.errors
+
+    def test_saves_for_chosen_conference(self, conference):
+        form = SponsorshipTierForm(
+            data={
+                "conference": conference.pk,
+                "name": "Gold",
+                "amount": "1000",
+                "description": "d",
+            }
+        )
+        assert form.is_valid()
+        tier = form.save()
+        assert tier.conference == conference

--- a/tests/volunteer/test_views.py
+++ b/tests/volunteer/test_views.py
@@ -111,6 +111,29 @@ class TestVolunteer:
         response = client.get(reverse("volunteer:volunteer_profile_new"))
         assert response.status_code == 200
 
+    def test_create_blocked_without_active_conference(
+        self, client, portal_user, conference
+    ):
+        # A profile is tied to the active edition; with none active, don't offer
+        # (or accept) the form — redirect back to the hub instead of 500-ing.
+        conference.is_active = False
+        conference.save()
+        client.force_login(portal_user)
+        response = client.get(reverse("volunteer:volunteer_profile_new"), follow=True)
+        assert response.status_code == 200
+        assert response.request["PATH_INFO"] == reverse("volunteer:index")
+        assert not VolunteerProfile.objects.filter(user=portal_user).exists()
+
+    def test_hub_hides_create_button_without_active_conference(
+        self, client, portal_user, conference
+    ):
+        conference.is_active = False
+        conference.save()
+        client.force_login(portal_user)
+        content = client.get(reverse("volunteer:index")).content.decode()
+        assert "Volunteer sign-ups open once" in content
+        assert reverse("volunteer:volunteer_profile_new") not in content
+
     def test_volunteer_profile_teams_available(self, client, portal_user, conference):
         """Display team list if there are teams that are still accepting new members."""
 
@@ -1291,6 +1314,7 @@ class TestTeamCRUD:
         response = client.post(
             reverse("team_new"),
             {
+                "conference": conference.pk,
                 "short_name": "Comms",
                 "description": "Communications",
                 "open_to_new_members": "on",
@@ -1299,7 +1323,7 @@ class TestTeamCRUD:
         )
         assert response.status_code == 200
         team = Team.objects.get(short_name="Comms")
-        assert team.conference == conference  # the active edition
+        assert team.conference == conference  # the chosen edition
         assert team.open_to_new_members is True
 
     def test_team_form_notes_markdown_support(self, client, admin_user, conference):
@@ -1318,13 +1342,62 @@ class TestTeamCRUD:
         client.force_login(admin_user)
         response = client.post(
             reverse("team_edit", kwargs={"pk": team.pk}),
-            {"short_name": "Comms", "description": "new description"},
+            {
+                "conference": conference.pk,
+                "short_name": "Comms",
+                "description": "new description",
+            },
             follow=True,
         )
         assert response.status_code == 200
         team.refresh_from_db()
         assert team.description == "new description"
         assert team.open_to_new_members is False  # unchecked
+
+    def test_create_team_for_a_chosen_non_active_conference(
+        self, client, admin_user, conference
+    ):
+        past = Conference.objects.create(
+            year=2020, name="PyLadiesCon 2020", slug="2020"
+        )
+        client.force_login(admin_user)
+        client.post(
+            reverse("team_new"),
+            {"conference": past.pk, "short_name": "Comms", "description": "d"},
+            follow=True,
+        )
+        assert Team.objects.get(short_name="Comms").conference == past
+
+    def test_create_team_works_without_active_conference(
+        self, client, admin_user, conference
+    ):
+        # The conference is chosen on the form, so team creation no longer
+        # depends on an active edition existing.
+        conference.is_active = False
+        conference.save()
+        client.force_login(admin_user)
+        client.post(
+            reverse("team_new"),
+            {"conference": conference.pk, "short_name": "Infra", "description": "d"},
+            follow=True,
+        )
+        assert Team.objects.get(short_name="Infra").conference == conference
+
+    def test_team_form_shows_conference_selector(self, client, admin_user, conference):
+        client.force_login(admin_user)
+        content = client.get(reverse("team_new")).content.decode()
+        assert 'name="conference"' in content
+
+    def test_edit_team_form_renders_with_selector(
+        self, client, admin_user, conference
+    ):
+        team = Team.objects.create(
+            short_name="Comms", description="d", conference=conference
+        )
+        client.force_login(admin_user)
+        response = client.get(reverse("team_edit", kwargs={"pk": team.pk}))
+        assert response.status_code == 200
+        assert 'name="conference"' in response.content.decode()
 
     def test_delete_team(self, client, admin_user, conference):
         team = Team.objects.create(

--- a/volunteer/forms.py
+++ b/volunteer/forms.py
@@ -342,7 +342,13 @@ class TeamForm(ModelForm):
 
     class Meta:
         model = Team
-        fields = ["short_name", "description", "open_to_new_members", "team_leads"]
+        fields = [
+            "conference",
+            "short_name",
+            "description",
+            "open_to_new_members",
+            "team_leads",
+        ]
         help_texts = {
             "description": (
                 "Markdown supported: headings, lists, links, **bold**, "
@@ -352,8 +358,23 @@ class TeamForm(ModelForm):
 
     def __init__(self, *args, conference=None, **kwargs):
         super().__init__(*args, **kwargs)
-        # Team leads must be volunteers of the team's own edition. The views
-        # always pass the edition (active on create, the instance's on edit).
+        # The edition the team belongs to is now chosen on the form, so it works
+        # even when no edition is active. Default a new team to the caller's hint
+        # (the active edition).
+        if not self.instance.pk and conference is not None:
+            self.fields["conference"].initial = conference
+
+        # Team leads must be volunteers of the *team's own* edition. Scope the
+        # options to the conference in play: the submitted one on a bound form,
+        # else the instance's, else the caller's hint.
+        lead_conference = conference
+        if self.is_bound:
+            selected = self.data.get("conference")
+            lead_conference = (
+                Conference.objects.filter(pk=selected).first() if selected else None
+            )
+        elif self.instance.pk:
+            lead_conference = self.instance.conference
         self.fields["team_leads"].queryset = VolunteerProfile.objects.filter(
-            conference=conference
+            conference=lead_conference
         ).select_related("user")

--- a/volunteer/views.py
+++ b/volunteer/views.py
@@ -313,6 +313,17 @@ class VolunteerProfileCreate(CreateView):
     success_url = reverse_lazy("volunteer:index")
     form_class = VolunteerProfileForm
 
+    def dispatch(self, request, *args, **kwargs):
+        # Volunteer profiles are tied to the active edition; with none active
+        # there is nothing to sign up for, so don't offer (or accept) the form.
+        if request.user.is_authenticated and Conference.get_active() is None:
+            messages.info(
+                request,
+                "Volunteer sign-ups open once the next conference is active.",
+            )
+            return redirect("volunteer:index")
+        return super().dispatch(request, *args, **kwargs)
+
     def get(self, request, *args, **kwargs):
         # Only block if they have already applied for the *active* conference;
         # returning volunteers may apply afresh each year.
@@ -508,13 +519,9 @@ class TeamCreate(VolunteerAdminRequiredMixin, CreateView):
 
     def get_form_kwargs(self):
         kwargs = super().get_form_kwargs()
+        # A hint for the form's default conference; the field is now selectable.
         kwargs["conference"] = Conference.get_active()
         return kwargs
-
-    def form_valid(self, form):
-        # New teams belong to the active edition.
-        form.instance.conference = Conference.get_active()
-        return super().form_valid(form)
 
     def get_success_url(self):
         return reverse("team_detail", kwargs={"pk": self.object.pk})


### PR DESCRIPTION
Two related commits for the "no active conference" state (it's valid to have none: between editions, or a fresh install).

### 1. Surface it on the organizer dashboard
The Needs-attention panel said "Nothing needs your attention" when there was no active edition. Add a **"No active conference"** item (links to the conference list to activate one). Also add **"Manage sponsors"** to Quick actions alongside "Add sponsor".

### 2. Stop creation flows from 500-ing
Every year-bound record has a required, PROTECTed conference FK, so creating one with no active edition raised IntegrityError after submitting the form.

- **Volunteer profile** — tied to the active edition, so block creation when none is active (redirect from the form with a message) and hide the "Create my volunteer profile" button on the hub.
- **Sponsor** — the form already has a conference selector; validate one is chosen (or active) instead of failing on save.
- **Team** — add a **conference selector** to the create/edit form (also a requested feature), scoping team-lead options to the chosen edition; teams no longer depend on an active edition.
- **Tier** — already required an explicit conference; added a regression test.

**566 pass, 100% coverage**; black/isort/flake8/djlint clean.