### PR TITLE
Highlight the Add tab on the new-sponsor page

### DIFF
--- a/sponsorship/templates/sponsorship/_sponsorship_rail.html
+++ b/sponsorship/templates/sponsorship/_sponsorship_rail.html
@@ -21,5 +21,9 @@ the manager layout (base_sidebar); Tiers and Add are manager-only.
     {% endif %}
     <hr class="my-2">
     {% url 'sponsorship:sponsorship_profile_new' as add_url %}
-    {% include "portal/_sidebar_item.html" with url=add_url label=_("Add sponsor") icon="fa-plus" only %}
+    {% if active == "add" %}
+        {% include "portal/_sidebar_item.html" with url=add_url label=_("Add sponsor") icon="fa-plus" active=True only %}
+    {% else %}
+        {% include "portal/_sidebar_item.html" with url=add_url label=_("Add sponsor") icon="fa-plus" only %}
+    {% endif %}
 {% endif %}

--- a/sponsorship/templates/sponsorship/sponsorship_profile_form.html
+++ b/sponsorship/templates/sponsorship/sponsorship_profile_form.html
@@ -19,7 +19,11 @@
     {% trans "Sponsorship" %}
 {% endblock sidebar_title %}
 {% block sidebar %}
-    {% include "sponsorship/_sponsorship_rail.html" with active="sponsors" %}
+    {% if object.pk %}
+        {% include "sponsorship/_sponsorship_rail.html" with active="sponsors" %}
+    {% else %}
+        {% include "sponsorship/_sponsorship_rail.html" with active="add" %}
+    {% endif %}
 {% endblock sidebar %}
 {% block content %}
     <main>

--- a/tests/sponsorship/test_views.py
+++ b/tests/sponsorship/test_views.py
@@ -192,6 +192,35 @@ class TestSponsorshipRail:
         assert 'id="navSponsorship"' not in content  # dropdown removed
         assert "Manage tiers" not in content  # old dropdown item label gone
 
+    def test_add_sponsor_page_highlights_add(self, client, admin_user, conference):
+        client.force_login(admin_user)
+        content = client.get(
+            reverse("sponsorship:sponsorship_profile_new")
+        ).content.decode()
+        # The "Add sponsor" rail entry is current here, not "Sponsors".
+        assert self._active_href(
+            content, reverse("sponsorship:sponsorship_profile_new")
+        )
+        assert not self._active_href(content, reverse("sponsorship:sponsorship_list"))
+
+    def test_edit_sponsor_page_highlights_sponsors(
+        self, client, admin_user, conference
+    ):
+        sponsor = SponsorshipProfile.objects.create(
+            organization_name="Acme",
+            conference=conference,
+            progress_status=SponsorshipProgressStatus.PAID,
+        )
+        client.force_login(admin_user)
+        content = client.get(
+            reverse("sponsorship:sponsorship_profile_edit", kwargs={"pk": sponsor.pk})
+        ).content.decode()
+        # Editing an existing sponsor lives under "Sponsors", not "Add sponsor".
+        assert self._active_href(content, reverse("sponsorship:sponsorship_list"))
+        assert not self._active_href(
+            content, reverse("sponsorship:sponsorship_profile_new")
+        )
+
 
 @pytest.mark.django_db
 class TestSponsorshipViews:


### PR DESCRIPTION
The sponsorship rail always highlighted **Sponsors**, even on the add-new-sponsor page. Make **Add sponsor** highlightable and mark it current on the create page; editing an existing sponsor still highlights **Sponsors** (you got there from the list).

Tests assert the create page highlights Add (and not Sponsors), and the edit page highlights Sponsors (and not Add).

**100% coverage**; lint clean.